### PR TITLE
Fix database name in Docker Compose for easier connection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     container_name: gestion-del-fin-db
     environment:
       - MYSQL_ROOT_PASSWORD=admin
-      - MYSQL_DATABASE=gestion-del-fin-db
+      - MYSQL_DATABASE=gestion_del_fin
       - MYSQL_USER=admin
       - MYSQL_PASSWORD=admin
     ports:


### PR DESCRIPTION
This pull request makes a minor update to the `docker-compose.yml` file, specifically changing the database name for the MySQL container to use underscores instead of hyphens. This aligns the database name with common naming conventions and may improve compatibility.

* Changed the value of `MYSQL_DATABASE` from `gestion-del-fin-db` to `gestion_del_fin` in the MySQL service configuration in `docker-compose.yml`.