### PR TITLE
Enhance API documentation with Swagger and OpenAPI updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,8 @@
         "jsonwebtoken": "^9.0.3",
         "mariadb": "^3.5.2",
         "node-cron": "^4.2.1",
+        "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-express": "^5.0.1",
         "uuid": "^13.0.0",
         "winston": "^3.19.0",
         "winston-daily-rotate-file": "^5.0.0",
@@ -50,6 +52,68 @@
         "ts-node": "^10.9.2",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "license": "MIT"
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2761,6 +2825,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
+    },
     "node_modules/@kurkle/color": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
@@ -3236,6 +3306,13 @@
         }
       }
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
@@ -3496,7 +3573,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/jsonwebtoken": {
@@ -4664,6 +4740,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "license": "MIT"
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -5034,7 +5116,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/confbox": {
@@ -5451,6 +5532,18 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/dotenv": {
@@ -5958,7 +6051,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6333,7 +6425,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/fsevents": {
@@ -6847,7 +6938,6 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "once": "^1.3.0",
@@ -8601,6 +8691,13 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -8611,6 +8708,13 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
       "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
@@ -8642,6 +8746,12 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
       "license": "MIT"
     },
     "node_modules/lodash.once": {
@@ -9107,6 +9217,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -9229,7 +9346,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -10326,6 +10442,129 @@
         "node": ">=8"
       }
     },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/swagger-jsdoc/node_modules/brace-expansion": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.32.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.32.4.tgz",
+      "integrity": "sha512-0AADFFQNJzExEN49SrD/34Nn9cxNxVLiydYl2MBwSZFPVXNkVwC/EFAjoezGGqE8oDegiDC+p47t8lKObCinMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/synckit": {
       "version": "0.11.12",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
@@ -10847,6 +11086,15 @@
         }
       }
     },
+    "node_modules/validator": {
+      "version": "13.15.35",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.35.tgz",
+      "integrity": "sha512-TQ5pAGhd5whStmqWvYF4OjQROlmv9SMFVt37qoCBdqRffuuklWYQlCNnEs2ZaIBD1kZRNnikiZOS1eqgkar0iw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -11259,6 +11507,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/zeptomatch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,8 @@
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^25.5.0",
         "@types/node-cron": "^3.0.11",
+        "@types/swagger-jsdoc": "^6.0.4",
+        "@types/swagger-ui-express": "^4.1.8",
         "@typescript-eslint/eslint-plugin": "^8.57.0",
         "@typescript-eslint/parser": "^8.57.0",
         "cspell": "^9.7.0",
@@ -3661,6 +3663,24 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/swagger-jsdoc": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/swagger-jsdoc/-/swagger-jsdoc-6.0.4.tgz",
+      "integrity": "sha512-W+Xw5epcOZrF/AooUM/PccNMSAFOKWZA5dasNyMujTwsBkU74njSJBpvCCJhHAJ95XRMzQrrW844Btu0uoetwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/swagger-ui-express": {
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
+      "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/serve-static": "*"
+      }
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "jsonwebtoken": "^9.0.3",
     "mariadb": "^3.5.2",
     "node-cron": "^4.2.1",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.1",
     "uuid": "^13.0.0",
     "winston": "^3.19.0",
     "winston-daily-rotate-file": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^25.5.0",
     "@types/node-cron": "^3.0.11",
+    "@types/swagger-jsdoc": "^6.0.4",
+    "@types/swagger-ui-express": "^4.1.8",
     "@typescript-eslint/eslint-plugin": "^8.57.0",
     "@typescript-eslint/parser": "^8.57.0",
     "cspell": "^9.7.0",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -71,7 +71,7 @@ async function main() {
 
   const adminRole = await prisma.roles.create({
     data: {
-      name: 'ADMIN',
+      name: 'system_admin',
       description: 'Administrator with full access',
     },
   });

--- a/src/docs/swagger.ts
+++ b/src/docs/swagger.ts
@@ -5,7 +5,7 @@ const baseUrl = process.env.PUBLIC_BASE_URL || `http://localhost:${PORT}`; // TO
 
 export const swaggerSpec = swaggerJSDoc({
   definition: {
-    openapi: '6.2.8',
+    openapi: '3.2.0',
     info: {
       title: 'Gestion Del Fin API',
       version: '1.0.0',

--- a/src/docs/swagger.ts
+++ b/src/docs/swagger.ts
@@ -1,0 +1,57 @@
+import swaggerJSDoc from 'swagger-jsdoc';
+
+const PORT = process.env.PORT || 3000;
+const baseUrl = process.env.PUBLIC_BASE_URL || `http://localhost:${PORT}`; // TODO: add PUBLIC_BASE_URL to .env
+
+export const swaggerSpec = swaggerJSDoc({
+  definition: {
+    openapi: '6.2.8',
+    info: {
+      title: 'Gestion Del Fin API',
+      version: '1.0.0',
+      description: 'API documentation for Gestion Del Fin',
+    },
+    servers: [
+      {
+        url: baseUrl,
+        description: 'Development server',
+      },
+    ],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+        },
+      },
+      schemas: {
+        ErrorResponse: {
+          type: 'object',
+          properties: {
+            success: { type: 'boolean', example: false },
+            error: { type: 'string', example: 'Validation failed' },
+            details: {
+              type: 'array',
+              items: { type: 'string' },
+              example: ['name is required'],
+            },
+          },
+        },
+      },
+    },
+    tag: [
+      { name: 'System', description: 'System related endpoints' },
+      { name: 'Auth', description: 'Authentication & Session related endpoints' },
+      { name: 'Camps', description: 'Camps related endpoints' },
+      { name: 'Resources', description: 'Resources related endpoints' },
+      { name: 'People', description: 'People related endpoints' },
+      { name: 'inventory', description: 'Inventory related endpoints' },
+      { name: 'Admission', description: 'Admission related endpoints' },
+      { name: 'Users', description: 'Users related endpoints' },
+      { name: 'Roles', description: 'Roles related endpoints' },
+      { name: 'Professions', description: 'Professions related endpoints' },
+    ],
+  },
+  apis: ['./src/modules/**/*.routes.ts', './dist/modules/**/*.routes.js'],
+});

--- a/src/docs/swagger.ts
+++ b/src/docs/swagger.ts
@@ -5,7 +5,7 @@ const baseUrl = process.env.PUBLIC_BASE_URL || `http://localhost:${PORT}`;
 
 export const swaggerSpec = swaggerJSDoc({
   definition: {
-    openapi: '3.0.3',
+    openapi: '3.1.1',
     info: {
       title: 'Gestion Del Fin API',
       version: '1.0.0',

--- a/src/docs/swagger.ts
+++ b/src/docs/swagger.ts
@@ -1,11 +1,11 @@
 import swaggerJSDoc from 'swagger-jsdoc';
 
 const PORT = process.env.PORT || 3000;
-const baseUrl = process.env.PUBLIC_BASE_URL || `http://localhost:${PORT}`; // TODO: add PUBLIC_BASE_URL to .env
+const baseUrl = process.env.PUBLIC_BASE_URL || `http://localhost:${PORT}`;
 
 export const swaggerSpec = swaggerJSDoc({
   definition: {
-    openapi: '3.2.0',
+    openapi: '3.0.3',
     info: {
       title: 'Gestion Del Fin API',
       version: '1.0.0',
@@ -28,29 +28,91 @@ export const swaggerSpec = swaggerJSDoc({
       schemas: {
         ErrorResponse: {
           type: 'object',
+          required: ['error'],
           properties: {
-            success: { type: 'boolean', example: false },
-            error: { type: 'string', example: 'Validation failed' },
-            details: {
-              type: 'array',
-              items: { type: 'string' },
-              example: ['name is required'],
+            error: {
+              type: 'object',
+              required: ['message', 'statusCode'],
+              properties: {
+                message: { type: 'string', example: 'Validation failed' },
+                statusCode: { type: 'integer', example: 400 },
+                details: {
+                  description: 'Validation or database metadata details when available',
+                  nullable: true,
+                },
+              },
+            },
+          },
+        },
+        LoginRequest: {
+          type: 'object',
+          required: ['username', 'password'],
+          properties: {
+            username: {
+              type: 'string',
+              minLength: 1,
+              maxLength: 60,
+              example: 'admin',
+            },
+            password: {
+              type: 'string',
+              minLength: 1,
+              example: 'my-secure-password',
+            },
+          },
+        },
+        LoginResponse: {
+          type: 'object',
+          required: ['user', 'token'],
+          properties: {
+            user: {
+              type: 'object',
+              required: ['username'],
+              properties: {
+                username: { type: 'string', example: 'admin' },
+              },
+            },
+            token: {
+              type: 'string',
+              description: 'JWT access token',
+              example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+            },
+          },
+        },
+        SystemTimeResponse: {
+          type: 'object',
+          required: ['now', 'iso', 'today'],
+          properties: {
+            now: {
+              type: 'string',
+              description: 'Server local time',
+              example: '14:05:30',
+            },
+            iso: {
+              type: 'string',
+              format: 'date-time',
+              example: '2026-04-25T14:05:30.000Z',
+            },
+            today: {
+              type: 'string',
+              format: 'date',
+              example: '2026-04-25',
             },
           },
         },
       },
     },
-    tag: [
-      { name: 'System', description: 'System related endpoints' },
-      { name: 'Auth', description: 'Authentication & Session related endpoints' },
-      { name: 'Camps', description: 'Camps related endpoints' },
-      { name: 'Resources', description: 'Resources related endpoints' },
-      { name: 'People', description: 'People related endpoints' },
-      { name: 'inventory', description: 'Inventory related endpoints' },
-      { name: 'Admission', description: 'Admission related endpoints' },
-      { name: 'Users', description: 'Users related endpoints' },
-      { name: 'Roles', description: 'Roles related endpoints' },
-      { name: 'Professions', description: 'Professions related endpoints' },
+    tags: [
+      { name: 'System', description: 'System and health-related endpoints' },
+      { name: 'Auth', description: 'Authentication and session endpoints' },
+      { name: 'Camps', description: 'Camp management endpoints' },
+      { name: 'Resources', description: 'Resource catalog endpoints' },
+      { name: 'People', description: 'People management endpoints' },
+      { name: 'Inventory', description: 'Inventory and audit endpoints' },
+      { name: 'Admission', description: 'Admission workflow endpoints' },
+      { name: 'Users', description: 'User management endpoints' },
+      { name: 'Professions', description: 'Profession catalog endpoints' },
+      { name: 'Explorations', description: 'Exploration lifecycle endpoints' },
     ],
   },
   apis: ['./src/modules/**/*.routes.ts', './dist/modules/**/*.routes.js'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,10 @@ import { errorHandler } from './middlewares/error.middleware.js';
 import { authMiddleware } from './middlewares/auth.middleware.js';
 import { sessionMiddleware } from './middlewares/session.middleware.js';
 import { campMiddleware } from './middlewares/camp.middleware.js';
+import { swaggerSpec } from './docs/swagger.js';
 
 import express from 'express';
+import swaggerUi from 'swagger-ui-express';
 import systemRoutes from './modules/system/system.routes.js';
 import campsRoutes from './modules/camps/camps.routes.js';
 
@@ -25,6 +27,7 @@ app.get('/', (req, res) => {
 });
 
 app.use(express.json());
+
 app.use('/api/system', systemRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/resources', authMiddleware, sessionMiddleware, campMiddleware, resourcesRoutes);
@@ -35,6 +38,13 @@ app.use('/api/professions', authMiddleware, sessionMiddleware, campMiddleware, p
 
 app.use('/api/inventory', authMiddleware, sessionMiddleware, campMiddleware, inventoryRoutes);
 app.use('/api/admission', authMiddleware, sessionMiddleware, campMiddleware, admissionRoutes);
+
+app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+app.get('/docs.json', (req, res) => {
+  res.setHeader('Content-Type', 'application/json');
+  res.send(swaggerSpec);
+});
+
 app.use(errorHandler);
 
 const PORT = process.env.PORT || 3000;

--- a/src/modules/admission/admission.routes.ts
+++ b/src/modules/admission/admission.routes.ts
@@ -7,6 +7,48 @@ import { idParamsSchema } from '../../shared/schemas/http.schema.js';
 import { roleMiddleware } from '../../middlewares/role.middleware.js';
 
 const router = Router();
+
+/**
+ * @openapi
+ * /api/admission/camps/{campId}:
+ *   post:
+ *     tags: [Admission]
+ *     summary: Create admission request
+ *     description: Creates an admission request for a specific camp.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: campId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             description: Payload validated by createAdmissionSchema.
+ *     responses:
+ *       201:
+ *         description: Admission request created successfully.
+ *       400:
+ *         description: Invalid request payload or path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Camp not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.post(
   '/camps/:campId',
   validate(
@@ -18,18 +60,127 @@ router.post(
   admissionController.createAdmissionHandler,
 );
 
+/**
+ * @openapi
+ * /api/admission/camps/{campId}:
+ *   get:
+ *     tags: [Admission]
+ *     summary: List admissions by camp
+ *     description: Returns admission requests for a camp.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: campId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     responses:
+ *       200:
+ *         description: Admissions retrieved successfully.
+ *       400:
+ *         description: Invalid path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Camp not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.get(
   '/camps/:campId',
   validate(z.object({ params: z.object({ campId: z.coerce.number().int().positive() }) })),
   admissionController.getAdmissionsHandler,
 );
 
+/**
+ * @openapi
+ * /api/admission/{id}:
+ *   get:
+ *     tags: [Admission]
+ *     summary: Get admission by id
+ *     description: Returns one admission request by numeric id.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     responses:
+ *       200:
+ *         description: Admission retrieved successfully.
+ *       400:
+ *         description: Invalid path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Admission not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.get(
   '/:id',
   validate(z.object({ params: idParamsSchema })),
   admissionController.getAdmissionHandler,
 );
 
+/**
+ * @openapi
+ * /api/admission/{id}/review:
+ *   patch:
+ *     tags: [Admission]
+ *     summary: Review admission
+ *     description: Approves or rejects an admission request. Requires role system_admin.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             description: Review payload validated by reviewAdmissionSchema.
+ *     responses:
+ *       200:
+ *         description: Admission reviewed successfully.
+ *       400:
+ *         description: Invalid request payload or path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Admission not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.patch(
   '/:id/review',
   roleMiddleware(['system_admin']),

--- a/src/modules/auth/auth.routes.ts
+++ b/src/modules/auth/auth.routes.ts
@@ -5,6 +5,45 @@ import { LoginSchema } from './auth.schema.js';
 
 const router = Router();
 
+/**
+ * @openapi
+ * /api/auth/login:
+ *   post:
+ *     tags: [Auth]
+ *     summary: Authenticate user and return access token
+ *     description: Validates username and password credentials and returns a JWT access token.
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/LoginRequest'
+ *     responses:
+ *       200:
+ *         description: Login successful.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/LoginResponse'
+ *       400:
+ *         description: Request payload validation failed.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Invalid credentials.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       500:
+ *         description: Unexpected server error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ */
 router.post('/login', validate(LoginSchema), authController.login);
 
 export default router;

--- a/src/modules/camps/camps.routes.ts
+++ b/src/modules/camps/camps.routes.ts
@@ -9,29 +9,220 @@ import { roleMiddleware } from '../../middlewares/role.middleware.js';
 
 const router = Router();
 
+/**
+ * @openapi
+ * /api/camps:
+ *   post:
+ *     tags: [Camps]
+ *     summary: Create a new camp
+ *     description: Creates a camp. Requires role system_admin.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [name]
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 minLength: 1
+ *                 maxLength: 100
+ *               location:
+ *                 type: string
+ *                 maxLength: 100
+ *               status:
+ *                 type: string
+ *                 enum: [ACTIVE, ABANDONED]
+ *               ai_context_prompt:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Camp created successfully.
+ *       400:
+ *         description: Validation failed.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       409:
+ *         description: Conflict with existing data.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.post(
   '/',
   roleMiddleware(['system_admin']),
   validate(z.object({ body: createCampSchema })),
   campsController.createCampHandler,
 );
+
+/**
+ * @openapi
+ * /api/camps:
+ *   get:
+ *     tags: [Camps]
+ *     summary: List camps
+ *     description: Returns all camps visible to authorized roles.
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Camps retrieved successfully.
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.get(
   '/',
   roleMiddleware(['system_admin', 'worker', 'resource_manager', 'travel_coordinator']),
   campsController.getCampsHandler,
 );
+
+/**
+ * @openapi
+ * /api/camps/{id}:
+ *   get:
+ *     tags: [Camps]
+ *     summary: Get camp by id
+ *     description: Returns one camp by numeric id.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     responses:
+ *       200:
+ *         description: Camp retrieved successfully.
+ *       400:
+ *         description: Invalid path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Camp not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.get(
   '/:id',
   roleMiddleware(['system_admin', 'worker', 'resource_manager', 'travel_coordinator']),
   validate(z.object({ params: idParamsSchema })),
   campsController.getCampHandler,
 );
+
+/**
+ * @openapi
+ * /api/camps/{id}:
+ *   put:
+ *     tags: [Camps]
+ *     summary: Update camp
+ *     description: Updates one camp by id. Requires role system_admin.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 minLength: 1
+ *                 maxLength: 100
+ *               location:
+ *                 type: string
+ *                 maxLength: 100
+ *               status:
+ *                 type: string
+ *                 enum: [ACTIVE, ABANDONED]
+ *               ai_context_prompt:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Camp updated successfully.
+ *       400:
+ *         description: Invalid request payload or path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Camp not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.put(
   '/:id',
   roleMiddleware(['system_admin']),
   validate(z.object({ params: idParamsSchema, body: updateCampSchema })),
   campsController.updateCampHandler,
 );
+
+/**
+ * @openapi
+ * /api/camps/{id}:
+ *   delete:
+ *     tags: [Camps]
+ *     summary: Delete camp
+ *     description: Deletes one camp by id. Requires role system_admin.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     responses:
+ *       204:
+ *         description: Camp deleted successfully.
+ *       400:
+ *         description: Invalid path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Camp not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.delete(
   '/:id',
   roleMiddleware(['system_admin']),

--- a/src/modules/explorations/explorations.routes.ts
+++ b/src/modules/explorations/explorations.routes.ts
@@ -13,35 +13,248 @@ import { roleMiddleware } from '../../middlewares/role.middleware.js';
 
 const router = Router();
 
+/**
+ * @openapi
+ * /api/expeditions:
+ *   post:
+ *     tags: [Explorations]
+ *     summary: Create expedition
+ *     description: Creates an expedition plan. Requires role travel_coordinator.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             description: Expedition payload validated by createExplorationSchema.
+ *     responses:
+ *       201:
+ *         description: Expedition created successfully.
+ *       400:
+ *         description: Validation failed.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.post(
   '/',
   roleMiddleware(['travel_coordinator']),
   validate(z.object({ body: createExplorationSchema })),
   explorationsController.createExplorationHandler,
 );
+
+/**
+ * @openapi
+ * /api/expeditions:
+ *   get:
+ *     tags: [Explorations]
+ *     summary: List expeditions
+ *     description: Returns all expeditions visible to authorized roles.
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Expeditions retrieved successfully.
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.get(
   '/',
   roleMiddleware(['system_admin', 'worker', 'resource_manager', 'travel_coordinator']),
   explorationsController.listExplorationsHandler,
 );
+
+/**
+ * @openapi
+ * /api/expeditions/{id}:
+ *   get:
+ *     tags: [Explorations]
+ *     summary: Get expedition by id
+ *     description: Returns one expedition by numeric id.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     responses:
+ *       200:
+ *         description: Expedition retrieved successfully.
+ *       400:
+ *         description: Invalid path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Expedition not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.get(
   '/:id',
   roleMiddleware(['system_admin', 'worker', 'resource_manager', 'travel_coordinator']),
   validate(z.object({ params: idParamsSchema })),
   explorationsController.getExplorationHandler,
 );
+
+/**
+ * @openapi
+ * /api/expeditions/{id}:
+ *   put:
+ *     tags: [Explorations]
+ *     summary: Update expedition
+ *     description: Updates expedition details. Requires role travel_coordinator.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             description: Expedition update payload validated by updateExplorationSchema.
+ *     responses:
+ *       200:
+ *         description: Expedition updated successfully.
+ *       400:
+ *         description: Invalid request payload or path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Expedition not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.put(
   '/:id',
   roleMiddleware(['travel_coordinator']),
   validate(z.object({ params: idParamsSchema, body: updateExplorationSchema })),
   explorationsController.updateExplorationHandler,
 );
+
+/**
+ * @openapi
+ * /api/expeditions/{id}/status:
+ *   patch:
+ *     tags: [Explorations]
+ *     summary: Update expedition status
+ *     description: Updates only expedition lifecycle status. Requires role travel_coordinator.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             description: Status payload validated by updateExplorationStatusSchema.
+ *     responses:
+ *       200:
+ *         description: Expedition status updated successfully.
+ *       400:
+ *         description: Invalid request payload or path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Expedition not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.patch(
   '/:id/status',
   roleMiddleware(['travel_coordinator']),
   validate(z.object({ params: idParamsSchema, body: updateExplorationStatusSchema })),
   explorationsController.updateExplorationStatusHandler,
 );
+
+/**
+ * @openapi
+ * /api/expeditions/{id}:
+ *   delete:
+ *     tags: [Explorations]
+ *     summary: Delete expedition
+ *     description: Deletes an expedition by id. Requires role travel_coordinator.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             description: Deletion payload validated by deleteExplorationSchema.
+ *     responses:
+ *       204:
+ *         description: Expedition deleted successfully.
+ *       400:
+ *         description: Invalid request payload or path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Expedition not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.delete(
   '/:id',
   roleMiddleware(['travel_coordinator']),

--- a/src/modules/inventory/inventory.routes.ts
+++ b/src/modules/inventory/inventory.routes.ts
@@ -11,6 +11,40 @@ import { roleMiddleware } from '../../middlewares/role.middleware.js';
 
 const router = Router();
 
+/**
+ * @openapi
+ * /api/inventory/{campId}:
+ *   get:
+ *     tags: [Inventory]
+ *     summary: Get inventory snapshot by camp
+ *     description: Returns current inventory balances for a camp.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: campId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     responses:
+ *       200:
+ *         description: Inventory retrieved successfully.
+ *       400:
+ *         description: Invalid camp id.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Camp not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.get(
   '/:campId',
   roleMiddleware(['system_admin', 'worker', 'resource_manager', 'travel_coordinator']),
@@ -18,6 +52,40 @@ router.get(
   getCampInventoryHandler,
 );
 
+/**
+ * @openapi
+ * /api/inventory/audit/{campId}:
+ *   get:
+ *     tags: [Inventory]
+ *     summary: Get inventory audit trail by camp
+ *     description: Returns inventory adjustment and movement audit records for a camp.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: campId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     responses:
+ *       200:
+ *         description: Inventory audit retrieved successfully.
+ *       400:
+ *         description: Invalid camp id.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Camp not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.get(
   '/audit/:campId',
   roleMiddleware(['system_admin', 'resource_manager']),
@@ -25,6 +93,51 @@ router.get(
   getInventoryAuditHandler,
 );
 
+/**
+ * @openapi
+ * /api/inventory/adjustment:
+ *   post:
+ *     tags: [Inventory]
+ *     summary: Create manual inventory adjustment
+ *     description: Applies a manual stock adjustment entry for a camp/resource combination.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [camp_id, resource_id, quantity_delta]
+ *             properties:
+ *               camp_id:
+ *                 type: integer
+ *                 minimum: 1
+ *               resource_id:
+ *                 type: integer
+ *                 minimum: 1
+ *               quantity_delta:
+ *                 type: number
+ *               reason:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Adjustment created successfully.
+ *       400:
+ *         description: Validation failed.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Camp or resource not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.post(
   '/adjustment',
   roleMiddleware(['worker', 'resource_manager']),

--- a/src/modules/people/people.routes.ts
+++ b/src/modules/people/people.routes.ts
@@ -25,48 +25,395 @@ import { roleMiddleware } from '../../middlewares/role.middleware.js';
 
 const router = Router({ mergeParams: true });
 
+/**
+ * @openapi
+ * /api/camps/{campId}/people:
+ *   post:
+ *     tags: [People]
+ *     summary: Create person in camp
+ *     description: Creates a person linked to a camp. Requires role system_admin.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: campId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             description: Payload validated by createPersonSchema.
+ *     responses:
+ *       201:
+ *         description: Person created successfully.
+ *       400:
+ *         description: Invalid request payload or path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Camp not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.post(
   '/',
   roleMiddleware(['system_admin']),
   validate(z.object({ params: campIdParamsSchema, body: createPersonSchema })),
   createPersonHandler,
 );
+
+/**
+ * @openapi
+ * /api/camps/{campId}/people/status-log:
+ *   post:
+ *     tags: [People]
+ *     summary: Add person status log
+ *     description: Creates a status log event for a person within a camp.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: campId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             description: Payload validated by createPersonStatusLogSchema.
+ *     responses:
+ *       201:
+ *         description: Status log created successfully.
+ *       400:
+ *         description: Invalid request payload or path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Camp or person not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.post(
   '/status-log',
   roleMiddleware(['system_admin', 'resource_manager']),
   validate(z.object({ params: campIdParamsSchema, body: createPersonStatusLogSchema })),
   createPersonStatusLogHandler,
 );
+
+/**
+ * @openapi
+ * /api/camps/{campId}/people/profession-reassignments:
+ *   post:
+ *     tags: [People]
+ *     summary: Create profession reassignment
+ *     description: Reassigns a person to a profession for a camp context.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: campId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             description: Payload validated by createProfessionReassignmentSchema.
+ *     responses:
+ *       201:
+ *         description: Profession reassignment created successfully.
+ *       400:
+ *         description: Invalid request payload or path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Camp, person, or profession not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.post(
   '/profession-reassignments',
   roleMiddleware(['system_admin', 'resource_manager']),
   validate(z.object({ params: campIdParamsSchema, body: createProfessionReassignmentSchema })),
   createProfessionReassignmentHandler,
 );
+
+/**
+ * @openapi
+ * /api/camps/{campId}/people/contribution-overrides:
+ *   post:
+ *     tags: [People]
+ *     summary: Create contribution override
+ *     description: Creates a contribution override for a person in a camp.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: campId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             description: Payload validated by createContributionOverrideSchema.
+ *     responses:
+ *       201:
+ *         description: Contribution override created successfully.
+ *       400:
+ *         description: Invalid request payload or path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Camp or person not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.post(
   '/contribution-overrides',
   roleMiddleware(['resource_manager']),
   validate(z.object({ params: campIdParamsSchema, body: createContributionOverrideSchema })),
   createContributionOverrideHandler,
 );
+
+/**
+ * @openapi
+ * /api/camps/{campId}/people:
+ *   get:
+ *     tags: [People]
+ *     summary: List people by camp
+ *     description: Returns people for a camp with pagination.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: campId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *       - in: query
+ *         name: page
+ *         required: false
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *       - in: query
+ *         name: limit
+ *         required: false
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 10
+ *     responses:
+ *       200:
+ *         description: People retrieved successfully.
+ *       400:
+ *         description: Invalid path or query parameters.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Camp not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.get(
   '/',
   roleMiddleware(['system_admin', 'worker', 'resource_manager', 'travel_coordinator']),
   validate(z.object({ params: campIdParamsSchema, query: paginationQuerySchema })),
   getPeopleHandler,
 );
+
+/**
+ * @openapi
+ * /api/camps/{campId}/people/{id}:
+ *   get:
+ *     tags: [People]
+ *     summary: Get person by id
+ *     description: Returns one person from a camp by numeric id.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: campId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     responses:
+ *       200:
+ *         description: Person retrieved successfully.
+ *       400:
+ *         description: Invalid path parameters.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Camp or person not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.get(
   '/:id',
   roleMiddleware(['system_admin', 'worker', 'resource_manager', 'travel_coordinator']),
   validate(z.object({ params: campIdAndPersonIdParamsSchema })),
   getPersonHandler,
 );
+
+/**
+ * @openapi
+ * /api/camps/{campId}/people/{id}:
+ *   put:
+ *     tags: [People]
+ *     summary: Update person
+ *     description: Updates a person in a camp. Requires role system_admin or resource_manager.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: campId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             description: Payload validated by updatePersonSchema.
+ *     responses:
+ *       200:
+ *         description: Person updated successfully.
+ *       400:
+ *         description: Invalid request payload or path parameters.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Camp or person not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.put(
   '/:id',
   roleMiddleware(['system_admin', 'resource_manager']),
   validate(z.object({ params: campIdAndPersonIdParamsSchema, body: updatePersonSchema })),
   updatePersonHandler,
 );
+
+/**
+ * @openapi
+ * /api/camps/{campId}/people/{id}:
+ *   delete:
+ *     tags: [People]
+ *     summary: Delete person
+ *     description: Deletes a person from a camp. Requires role system_admin.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: campId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     responses:
+ *       204:
+ *         description: Person deleted successfully.
+ *       400:
+ *         description: Invalid path parameters.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Camp or person not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.delete(
   '/:id',
   roleMiddleware(['system_admin']),

--- a/src/modules/professions/professions.routes.ts
+++ b/src/modules/professions/professions.routes.ts
@@ -8,29 +8,206 @@ import { roleMiddleware } from '../../middlewares/role.middleware.js';
 
 const router = Router();
 
+/**
+ * @openapi
+ * /api/professions:
+ *   post:
+ *     tags: [Professions]
+ *     summary: Create profession
+ *     description: Creates a profession record. Requires role system_admin.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [name]
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 minLength: 1
+ *                 maxLength: 80
+ *               description:
+ *                 type: string
+ *     responses:
+ *       201:
+ *         description: Profession created successfully.
+ *       400:
+ *         description: Validation failed.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.post(
   '/',
   roleMiddleware(['system_admin']),
   validate(z.object({ body: createProfessionSchema })),
   professionsController.createProfessionHandler,
 );
+
+/**
+ * @openapi
+ * /api/professions:
+ *   get:
+ *     tags: [Professions]
+ *     summary: List professions
+ *     description: Returns all profession records available to authorized roles.
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Professions retrieved successfully.
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.get(
   '/',
   roleMiddleware(['system_admin', 'worker', 'resource_manager', 'travel_coordinator']),
   professionsController.listProfessionsHandler,
 );
+
+/**
+ * @openapi
+ * /api/professions/{id}:
+ *   get:
+ *     tags: [Professions]
+ *     summary: Get profession by id
+ *     description: Returns one profession by numeric id.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     responses:
+ *       200:
+ *         description: Profession retrieved successfully.
+ *       400:
+ *         description: Invalid path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Profession not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.get(
   '/:id',
   roleMiddleware(['system_admin', 'worker', 'resource_manager', 'travel_coordinator']),
   validate(z.object({ params: idParamsSchema })),
   professionsController.getProfessionHandler,
 );
+
+/**
+ * @openapi
+ * /api/professions/{id}:
+ *   put:
+ *     tags: [Professions]
+ *     summary: Update profession
+ *     description: Updates one profession by id. Requires role system_admin.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 minLength: 1
+ *                 maxLength: 80
+ *               description:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Profession updated successfully.
+ *       400:
+ *         description: Invalid request payload or path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Profession not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.put(
   '/:id',
   roleMiddleware(['system_admin']),
   validate(z.object({ params: idParamsSchema, body: updateProfessionSchema })),
   professionsController.updateProfessionHandler,
 );
+
+/**
+ * @openapi
+ * /api/professions/{id}:
+ *   delete:
+ *     tags: [Professions]
+ *     summary: Delete profession
+ *     description: Deletes one profession by id. Requires role system_admin.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     responses:
+ *       204:
+ *         description: Profession deleted successfully.
+ *       400:
+ *         description: Invalid path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Profession not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.delete(
   '/:id',
   roleMiddleware(['system_admin']),

--- a/src/modules/resources/resources.routes.ts
+++ b/src/modules/resources/resources.routes.ts
@@ -8,30 +8,249 @@ import { roleMiddleware } from '../../middlewares/role.middleware.js';
 
 const router = Router();
 
+/**
+ * @openapi
+ * /api/resources:
+ *   post:
+ *     tags: [Resources]
+ *     summary: Create a resource type
+ *     description: Creates a resource definition. Requires role resource_manager.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [name, unit, daily_ration, minimum_stock]
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 minLength: 1
+ *                 maxLength: 80
+ *               unit:
+ *                 type: string
+ *                 minLength: 1
+ *                 maxLength: 20
+ *               daily_ration:
+ *                 type: number
+ *                 minimum: 0
+ *               minimum_stock:
+ *                 type: number
+ *                 minimum: 0
+ *               auto_daily:
+ *                 type: boolean
+ *     responses:
+ *       201:
+ *         description: Resource created successfully.
+ *       400:
+ *         description: Validation failed.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.post(
   '/',
   roleMiddleware(['resource_manager']),
   validate(z.object({ body: createResourceSchema })),
   resourcesController.createResourceHandler,
 );
+
+/**
+ * @openapi
+ * /api/resources:
+ *   get:
+ *     tags: [Resources]
+ *     summary: List resources
+ *     description: Returns resources with optional pagination.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         required: false
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           default: 1
+ *       - in: query
+ *         name: limit
+ *         required: false
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *           maximum: 100
+ *           default: 10
+ *     responses:
+ *       200:
+ *         description: Resources retrieved successfully.
+ *       400:
+ *         description: Invalid query parameters.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.get(
   '/',
   roleMiddleware(['system_admin', 'worker', 'resource_manager', 'travel_coordinator']),
   validate(z.object({ query: paginationQuerySchema })),
   resourcesController.listResourcesHandler,
 );
+
+/**
+ * @openapi
+ * /api/resources/{id}:
+ *   get:
+ *     tags: [Resources]
+ *     summary: Get resource by id
+ *     description: Returns one resource by numeric id.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     responses:
+ *       200:
+ *         description: Resource retrieved successfully.
+ *       400:
+ *         description: Invalid path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Resource not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.get(
   '/:id',
   roleMiddleware(['system_admin', 'worker', 'resource_manager', 'travel_coordinator']),
   validate(z.object({ params: idParamsSchema })),
   resourcesController.getResourceHandler,
 );
+
+/**
+ * @openapi
+ * /api/resources/{id}:
+ *   put:
+ *     tags: [Resources]
+ *     summary: Update resource
+ *     description: Updates a resource by id. Requires role resource_manager.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               name:
+ *                 type: string
+ *                 minLength: 1
+ *                 maxLength: 80
+ *               unit:
+ *                 type: string
+ *                 minLength: 1
+ *                 maxLength: 20
+ *               daily_ration:
+ *                 type: number
+ *                 minimum: 0
+ *               minimum_stock:
+ *                 type: number
+ *                 minimum: 0
+ *               auto_daily:
+ *                 type: boolean
+ *     responses:
+ *       200:
+ *         description: Resource updated successfully.
+ *       400:
+ *         description: Invalid request payload or path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Resource not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.put(
   '/:id',
   roleMiddleware(['resource_manager']),
   validate(z.object({ params: idParamsSchema, body: updateResourceSchema })),
   resourcesController.updateResourceHandler,
 );
+
+/**
+ * @openapi
+ * /api/resources/{id}:
+ *   delete:
+ *     tags: [Resources]
+ *     summary: Delete resource
+ *     description: Deletes a resource by id. Requires role resource_manager.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     responses:
+ *       204:
+ *         description: Resource deleted successfully.
+ *       400:
+ *         description: Invalid path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: Resource not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.delete(
   '/:id',
   roleMiddleware(['resource_manager']),

--- a/src/modules/system/system.routes.ts
+++ b/src/modules/system/system.routes.ts
@@ -5,10 +5,24 @@ const router = Router();
 
 /**
  * @openapi
- * /api/time:
- *  get:
- *    tags: [System]
- *    summary: Get current system time
+ * /api/system/time:
+ *   get:
+ *     tags: [System]
+ *     summary: Get server time snapshot
+ *     description: Returns the current server time in multiple formats.
+ *     responses:
+ *       200:
+ *         description: Current server time returned successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/SystemTimeResponse'
+ *       500:
+ *         description: Unexpected server error.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
  */
 router.get('/time', getServerTimeHandler);
 

--- a/src/modules/system/system.routes.ts
+++ b/src/modules/system/system.routes.ts
@@ -3,6 +3,13 @@ import { getServerTimeHandler } from './system.controller.js';
 
 const router = Router();
 
+/**
+ * @openapi
+ * /api/time:
+ *  get:
+ *    tags: [System]
+ *    summary: Get current system time
+ */
 router.get('/time', getServerTimeHandler);
 
 export default router;

--- a/src/modules/users/users.routes.ts
+++ b/src/modules/users/users.routes.ts
@@ -8,25 +8,236 @@ import { roleMiddleware } from '../../middlewares/role.middleware.js';
 
 const router = Router();
 
+/**
+ * @openapi
+ * /api/users:
+ *   post:
+ *     tags: [Users]
+ *     summary: Create user
+ *     description: Creates a user account. Requires role system_admin.
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [username, password, camp_id, role_id]
+ *             properties:
+ *               username:
+ *                 type: string
+ *                 minLength: 1
+ *                 maxLength: 60
+ *               password:
+ *                 type: string
+ *                 minLength: 1
+ *                 maxLength: 255
+ *               camp_id:
+ *                 type: integer
+ *                 minimum: 1
+ *               role_id:
+ *                 type: integer
+ *                 minimum: 1
+ *               is_active:
+ *                 type: boolean
+ *               last_activity:
+ *                 type: string
+ *                 format: date-time
+ *               created_at:
+ *                 type: string
+ *                 format: date-time
+ *     responses:
+ *       201:
+ *         description: User created successfully.
+ *       400:
+ *         description: Validation failed.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       409:
+ *         description: Username or constrained field already exists.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.post(
   '/',
   roleMiddleware(['system_admin']),
   validate(z.object({ body: CreateUserSchema })),
   usersController.createUserHandler,
 );
+
+/**
+ * @openapi
+ * /api/users:
+ *   get:
+ *     tags: [Users]
+ *     summary: List users
+ *     description: Returns all users. Requires role system_admin.
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       200:
+ *         description: Users retrieved successfully.
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.get('/', roleMiddleware(['system_admin']), usersController.getUsersHandler);
+
+/**
+ * @openapi
+ * /api/users/{id}:
+ *   get:
+ *     tags: [Users]
+ *     summary: Get user by id
+ *     description: Returns one user by numeric id. Requires role system_admin.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     responses:
+ *       200:
+ *         description: User retrieved successfully.
+ *       400:
+ *         description: Invalid path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: User not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.get(
   '/:id',
   roleMiddleware(['system_admin']),
   validate(z.object({ params: idParamsSchema })),
   usersController.getUserHandler,
 );
+
+/**
+ * @openapi
+ * /api/users/{id}:
+ *   put:
+ *     tags: [Users]
+ *     summary: Update user
+ *     description: Updates a user by id. Requires role system_admin.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               username:
+ *                 type: string
+ *                 minLength: 1
+ *                 maxLength: 60
+ *               password:
+ *                 type: string
+ *                 minLength: 1
+ *                 maxLength: 255
+ *               camp_id:
+ *                 type: integer
+ *                 minimum: 1
+ *               role_id:
+ *                 type: integer
+ *                 minimum: 1
+ *               is_active:
+ *                 type: boolean
+ *               last_activity:
+ *                 type: string
+ *                 format: date-time
+ *               created_at:
+ *                 type: string
+ *                 format: date-time
+ *     responses:
+ *       200:
+ *         description: User updated successfully.
+ *       400:
+ *         description: Invalid request payload or path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: User not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.put(
   '/:id',
   roleMiddleware(['system_admin']),
   validate(z.object({ params: idParamsSchema, body: UpdateUserSchema })),
   usersController.updateUserHandler,
 );
+
+/**
+ * @openapi
+ * /api/users/{id}:
+ *   delete:
+ *     tags: [Users]
+ *     summary: Delete user
+ *     description: Deletes a user by id. Requires role system_admin.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: integer
+ *           minimum: 1
+ *     responses:
+ *       204:
+ *         description: User deleted successfully.
+ *       400:
+ *         description: Invalid path parameter.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/ErrorResponse'
+ *       401:
+ *         description: Missing or invalid authentication.
+ *       403:
+ *         description: Forbidden for current user role.
+ *       404:
+ *         description: User not found.
+ *       500:
+ *         description: Unexpected server error.
+ */
 router.delete(
   '/:id',
   roleMiddleware(['system_admin']),


### PR DESCRIPTION
This pull request introduces comprehensive OpenAPI (Swagger) documentation for the API, making it easier for developers and users to understand and interact with the endpoints. It adds Swagger dependencies, sets up automated documentation generation and serving, and annotates key route files with detailed OpenAPI specs. There is also a minor update to the seed data for roles.

The most important changes are:

**API Documentation Infrastructure:**
* Added `swagger-jsdoc` and `swagger-ui-express` (and their TypeScript types) to dependencies in `package.json` to enable Swagger documentation generation and serving. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R39-R40) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R55-R56)
* Created `src/docs/swagger.ts` to define the OpenAPI specification, including API metadata, server info, security schemes, and commonly used schemas.
* Updated `src/index.ts` to serve the Swagger UI at `/docs` and the raw OpenAPI JSON at `/docs.json`, and to initialize Swagger middleware. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R8-R11) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R30) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R41-R47)

**Route Documentation:**
* Annotated the `admission.routes.ts`, `auth.routes.ts`, and `camps.routes.ts` files with detailed OpenAPI comments for all major endpoints, specifying request/response schemas, authentication requirements, and possible responses. [[1]](diffhunk://#diff-a04dca428af6fa47927ffee9c50dca3c462bf85b0d451e8407c6ace36a05765fR10-R51) [[2]](diffhunk://#diff-a04dca428af6fa47927ffee9c50dca3c462bf85b0d451e8407c6ace36a05765fR63-R183) [[3]](diffhunk://#diff-653d25cd3b441e992deb9861e96af42e6502a6366309273e72031a6f350e16f4R8-R46) [[4]](diffhunk://#diff-ab6d9b93fef50f76802d58e9b0a552c4661875845caea6b493609e57c68f6b7eR12-R225)

**Seed Data Update:**
* Changed the admin role name from `'ADMIN'` to `'system_admin'` in the Prisma seed script to match the new documentation and role requirements.