### PR TITLE
Implement transfers module with CRUD operations and update cspell dictionary

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -75,6 +75,7 @@
     "groq",
     "GROQ",
     "posible",
-    "esta"
+    "esta",
+    "Tocamps"
   ]
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -513,6 +513,133 @@ async function main() {
     ],
   });
 
+  // Seed transfers module data
+  console.log('Seeding transfers data...');
+
+  const pendingResourceTransfer = await prisma.camp_transfers.create({
+    data: {
+      requesting_camp: mainCamp.id,
+      target_camp: secondaryCamp.id,
+      status: 'PENDING',
+      type: 'RESOURCE',
+      notes: 'Emergency support package pending source approval',
+      requested_by: adminUser.id,
+      scheduled_delivery_date: new Date('2026-05-02T10:00:00Z'),
+    },
+  });
+
+  await prisma.camp_transfer_item.createMany({
+    data: [
+      {
+        camp_transfer_id: pendingResourceTransfer.id,
+        item_type: 'RESOURCE',
+        resource_type_id: rationsResource.id,
+        quantity: '30.00',
+      },
+      {
+        camp_transfer_id: pendingResourceTransfer.id,
+        item_type: 'RESOURCE',
+        resource_type_id: waterResource.id,
+        quantity: '60.00',
+      },
+    ],
+  });
+
+  const approvedSourceMixedTransfer = await prisma.camp_transfers.create({
+    data: {
+      requesting_camp: mainCamp.id,
+      target_camp: secondaryCamp.id,
+      status: 'APPROVED_SOURCE',
+      type: 'MIXED',
+      notes: 'Source approved. Awaiting target confirmation.',
+      requested_by: adminUser.id,
+      leader_person_id: quaternaryPerson.id,
+      scheduled_delivery_date: new Date('2026-05-03T14:30:00Z'),
+      approved_by_source: adminUser.id,
+      approved_source_at: new Date('2026-04-20T08:00:00Z'),
+    },
+  });
+
+  await prisma.camp_transfer_item.createMany({
+    data: [
+      {
+        camp_transfer_id: approvedSourceMixedTransfer.id,
+        item_type: 'PERSON',
+        person_id: quaternaryPerson.id,
+      },
+      {
+        camp_transfer_id: approvedSourceMixedTransfer.id,
+        item_type: 'RESOURCE',
+        resource_type_id: medsResource.id,
+        quantity: '8.00',
+      },
+    ],
+  });
+
+  const approvedTargetPersonTransfer = await prisma.camp_transfers.create({
+    data: {
+      requesting_camp: mainCamp.id,
+      target_camp: secondaryCamp.id,
+      status: 'APPROVED_TARGET',
+      type: 'PERSON',
+      notes: 'Fully approved transfer. Pending execution by logistics.',
+      requested_by: adminUser.id,
+      leader_person_id: primaryPerson.id,
+      scheduled_delivery_date: new Date('2026-05-04T09:15:00Z'),
+      approved_by_source: adminUser.id,
+      approved_source_at: new Date('2026-04-21T10:00:00Z'),
+      approved_by_target: standardUser.id,
+      approved_target_at: new Date('2026-04-22T11:30:00Z'),
+    },
+  });
+
+  await prisma.camp_transfer_item.createMany({
+    data: [
+      {
+        camp_transfer_id: approvedTargetPersonTransfer.id,
+        item_type: 'PERSON',
+        person_id: primaryPerson.id,
+      },
+      {
+        camp_transfer_id: approvedTargetPersonTransfer.id,
+        item_type: 'RESOURCE',
+        resource_type_id: rationsResource.id,
+        quantity: '6.00',
+      },
+      {
+        camp_transfer_id: approvedTargetPersonTransfer.id,
+        item_type: 'RESOURCE',
+        resource_type_id: waterResource.id,
+        quantity: '12.00',
+      },
+    ],
+  });
+
+  const rejectedTransfer = await prisma.camp_transfers.create({
+    data: {
+      requesting_camp: secondaryCamp.id,
+      target_camp: mainCamp.id,
+      status: 'REJECTED',
+      type: 'RESOURCE',
+      notes: 'Rejected by destination due to route risk escalation.',
+      requested_by: standardUser.id,
+      scheduled_delivery_date: new Date('2026-04-30T16:00:00Z'),
+      approved_by_source: standardUser.id,
+      approved_source_at: new Date('2026-04-18T09:00:00Z'),
+    },
+  });
+
+  await prisma.camp_transfer_item.createMany({
+    data: [
+      {
+        camp_transfer_id: rejectedTransfer.id,
+        item_type: 'RESOURCE',
+        resource_type_id: medsResource.id,
+        quantity: '4.00',
+      },
+    ],
+  });
+
   await prisma.system_config.create({
     data: {
       id: 1,

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import userRoutes from './modules/users/users.routes.js';
 import professionsRoutes from './modules/professions/professions.routes.js';
 import inventoryRoutes from './modules/inventory/inventory.routes.js';
 import admissionRoutes from './modules/admission/admission.routes.js';
+import transfersRoutes from './modules/transfers/transfers.routes.js';
 
 const app = express();
 
@@ -38,6 +39,7 @@ app.use('/api/professions', authMiddleware, sessionMiddleware, campMiddleware, p
 
 app.use('/api/inventory', authMiddleware, sessionMiddleware, campMiddleware, inventoryRoutes);
 app.use('/api/admission', authMiddleware, sessionMiddleware, campMiddleware, admissionRoutes);
+app.use('/api/transfers', authMiddleware, sessionMiddleware, campMiddleware, transfersRoutes);
 
 app.use('/api/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 app.get('/api/docs.json', (req, res) => {

--- a/src/modules/transfers/transfers.controller.ts
+++ b/src/modules/transfers/transfers.controller.ts
@@ -1,1 +1,64 @@
-// TODO: implement
+import { Request, Response } from 'express';
+import { parseIdParam } from '../../shared/utils/parseIdParam.js';
+import { AuthenticatedRequest } from '../../middlewares/auth.middleware.js';
+import {
+  approveTransferBySource,
+  approveTransferByTarget,
+  completeTransfer,
+  createTransfer,
+  getTransfer,
+  getTransfers,
+  rejectTransfer,
+  scheduleTransferDelivery,
+} from './transfers.service.js';
+
+export async function createTransferHandler(req: Request, res: Response) {
+  const result = await createTransfer(req.body);
+  return res.status(201).json(result);
+}
+
+export async function listTransfersHandler(_req: Request, res: Response) {
+  const result = await getTransfers();
+  return res.json(result);
+}
+
+export async function getTransferHandler(req: Request, res: Response) {
+  const id = parseIdParam(req.params.id);
+  const result = await getTransfer(id);
+  return res.json(result);
+}
+
+export async function scheduleTransferDeliveryHandler(req: Request, res: Response) {
+  const authReq = req as AuthenticatedRequest;
+  const id = parseIdParam(req.params.id);
+  const result = await scheduleTransferDelivery(id, authReq.user.userId, req.body);
+  return res.json(result);
+}
+
+export async function approveTransferBySourceHandler(req: Request, res: Response) {
+  const authReq = req as AuthenticatedRequest;
+  const id = parseIdParam(req.params.id);
+  const result = await approveTransferBySource(id, authReq.user.userId, req.body);
+  return res.json(result);
+}
+
+export async function approveTransferByTargetHandler(req: Request, res: Response) {
+  const authReq = req as AuthenticatedRequest;
+  const id = parseIdParam(req.params.id);
+  const result = await approveTransferByTarget(id, authReq.user.userId, req.body);
+  return res.json(result);
+}
+
+export async function completeTransferHandler(req: Request, res: Response) {
+  const authReq = req as AuthenticatedRequest;
+  const id = parseIdParam(req.params.id);
+  const result = await completeTransfer(id, authReq.user.userId, req.body);
+  return res.json(result);
+}
+
+export async function rejectTransferHandler(req: Request, res: Response) {
+  const authReq = req as AuthenticatedRequest;
+  const id = parseIdParam(req.params.id);
+  const result = await rejectTransfer(id, authReq.user.userId, req.body);
+  return res.json(result);
+}

--- a/src/modules/transfers/transfers.routes.ts
+++ b/src/modules/transfers/transfers.routes.ts
@@ -1,1 +1,61 @@
-// TODO: implement
+import { Router } from 'express';
+import { z } from 'zod';
+import { validate } from '../../middlewares/validate.middleware.js';
+import { idParamsSchema } from '../../shared/schemas/http.schema.js';
+import {
+  approveTransferSourceSchema,
+  approveTransferTargetSchema,
+  completeTransferSchema,
+  createTransferSchema,
+  rejectTransferSchema,
+  scheduleTransferDeliverySchema,
+} from './transfers.schema.js';
+import * as transfersController from './transfers.controller.js';
+
+const router = Router();
+
+router.post(
+  '/',
+  validate(z.object({ body: createTransferSchema })),
+  transfersController.createTransferHandler,
+);
+
+router.get('/', transfersController.listTransfersHandler);
+
+router.get(
+  '/:id',
+  validate(z.object({ params: idParamsSchema })),
+  transfersController.getTransferHandler,
+);
+
+router.patch(
+  '/:id/schedule',
+  validate(z.object({ params: idParamsSchema, body: scheduleTransferDeliverySchema })),
+  transfersController.scheduleTransferDeliveryHandler,
+);
+
+router.patch(
+  '/:id/approve-source',
+  validate(z.object({ params: idParamsSchema, body: approveTransferSourceSchema })),
+  transfersController.approveTransferBySourceHandler,
+);
+
+router.patch(
+  '/:id/approve-target',
+  validate(z.object({ params: idParamsSchema, body: approveTransferTargetSchema })),
+  transfersController.approveTransferByTargetHandler,
+);
+
+router.patch(
+  '/:id/complete',
+  validate(z.object({ params: idParamsSchema, body: completeTransferSchema })),
+  transfersController.completeTransferHandler,
+);
+
+router.patch(
+  '/:id/reject',
+  validate(z.object({ params: idParamsSchema, body: rejectTransferSchema })),
+  transfersController.rejectTransferHandler,
+);
+
+export default router;

--- a/src/modules/transfers/transfers.schema.ts
+++ b/src/modules/transfers/transfers.schema.ts
@@ -10,6 +10,9 @@ export const transferStatusEnum = z.enum([
 
 export const transferTypeEnum = z.enum(['RESOURCE', 'PERSON', 'MIXED']);
 export const transferItemTypeEnum = z.enum(['RESOURCE', 'PERSON']);
+export const personStatusEnum = z.enum(['SICK', 'HEALTHY', 'INJURED', 'AWAY', 'DEAD']);
+
+const dateTimeSchema = z.iso.datetime({ message: 'must be a valid ISO datetime' });
 
 export const transferItemSchema = z
   .object({
@@ -25,6 +28,14 @@ export const transferItemSchema = z
           code: 'custom',
           path: ['resource_type_id'],
           message: 'resource_type_id is required for RESOURCE items',
+        });
+      }
+
+      if (!item.quantity) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['quantity'],
+          message: 'quantity is required for RESOURCE items',
         });
       }
 
@@ -53,28 +64,125 @@ export const transferItemSchema = z
           message: 'resource_type_id must not be provided for PERSON items',
         });
       }
+
+      if (item.quantity) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['quantity'],
+          message: 'quantity must not be provided for PERSON items',
+        });
+      }
     }
   });
 
-export const createTransferSchema = z.object({
-  requesting_camp: z.number().int().positive(),
-  target_camp: z.number().int().positive(),
-  type: transferTypeEnum,
-  notes: z.string().optional(),
-  requested_by: z.number().int().positive(),
-  leader_person_id: z.number().int().positive().optional(),
-  scheduled_delivery_date: z.iso.datetime().optional(),
-  items: z.array(transferItemSchema).min(1),
+export const createTransferSchema = z
+  .object({
+    requesting_camp: z.number().int().positive(),
+    target_camp: z.number().int().positive(),
+    type: transferTypeEnum,
+    notes: z.string().optional(),
+    requested_by: z.number().int().positive(),
+    leader_person_id: z.number().int().positive().optional(),
+    scheduled_delivery_date: dateTimeSchema.optional(),
+    items: z.array(transferItemSchema).min(1),
+  })
+  .superRefine((data, ctx) => {
+    if (data.requesting_camp === data.target_camp) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['target_camp'],
+        message: 'target_camp must be different from requesting_camp',
+      });
+    }
+
+    const resourceItems = data.items.filter((item) => item.item_type === 'RESOURCE');
+    const personItems = data.items.filter((item) => item.item_type === 'PERSON');
+
+    if (data.type === 'RESOURCE' && personItems.length > 0) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['items'],
+        message: 'RESOURCE transfer cannot include PERSON items',
+      });
+    }
+
+    if (data.type === 'PERSON' && resourceItems.length === 0) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['items'],
+        message: 'PERSON transfer requires RESOURCE items for travel rations',
+      });
+    }
+
+    if (data.type === 'PERSON' && personItems.length === 0) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['items'],
+        message: 'PERSON transfer must include at least one PERSON item',
+      });
+    }
+
+    if (data.type === 'MIXED' && (resourceItems.length === 0 || personItems.length === 0)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['items'],
+        message: 'MIXED transfer must include both RESOURCE and PERSON items',
+      });
+    }
+
+    const seenResourceTypeIds = new Set<number>();
+    const seenPersonIds = new Set<number>();
+
+    data.items.forEach((item, index) => {
+      if (item.item_type === 'RESOURCE' && item.resource_type_id) {
+        if (seenResourceTypeIds.has(item.resource_type_id)) {
+          ctx.addIssue({
+            code: 'custom',
+            path: ['items', index, 'resource_type_id'],
+            message: 'duplicate resource_type_id values are not allowed',
+          });
+        }
+        seenResourceTypeIds.add(item.resource_type_id);
+      }
+
+      if (item.item_type === 'PERSON' && item.person_id) {
+        if (seenPersonIds.has(item.person_id)) {
+          ctx.addIssue({
+            code: 'custom',
+            path: ['items', index, 'person_id'],
+            message: 'duplicate person_id values are not allowed',
+          });
+        }
+        seenPersonIds.add(item.person_id);
+      }
+    });
+  });
+
+export const scheduleTransferDeliverySchema = z.object({
+  scheduled_delivery_date: dateTimeSchema,
 });
 
-export const updateTransferStatusSchema = z.object({
-  status: transferStatusEnum,
-  approved_by_source: z.number().int().positive().optional(),
-  approved_by_target: z.number().int().positive().optional(),
-  approved_source_at: z.iso.datetime().optional(),
-  approved_target_at: z.iso.datetime().optional(),
+export const approveTransferSourceSchema = z.object({
   notes: z.string().optional(),
+  scheduled_delivery_date: dateTimeSchema.optional(),
+});
+
+export const approveTransferTargetSchema = z.object({
+  notes: z.string().optional(),
+});
+
+export const completeTransferSchema = z.object({
+  notes: z.string().optional(),
+  person_status: personStatusEnum.optional(),
+});
+
+export const rejectTransferSchema = z.object({
+  reason: z.string().min(1, 'reason is required').max(500),
 });
 
 export type CreateTransferDto = z.infer<typeof createTransferSchema>;
-export type UpdateTransferStatusDto = z.infer<typeof updateTransferStatusSchema>;
+export type ScheduleTransferDeliveryDto = z.infer<typeof scheduleTransferDeliverySchema>;
+export type ApproveTransferSourceDto = z.infer<typeof approveTransferSourceSchema>;
+export type ApproveTransferTargetDto = z.infer<typeof approveTransferTargetSchema>;
+export type CompleteTransferDto = z.infer<typeof completeTransferSchema>;
+export type RejectTransferDto = z.infer<typeof rejectTransferSchema>;

--- a/src/modules/transfers/transfers.schema.ts
+++ b/src/modules/transfers/transfers.schema.ts
@@ -177,7 +177,7 @@ export const completeTransferSchema = z.object({
 });
 
 export const rejectTransferSchema = z.object({
-  reason: z.string().min(1, 'reason is required').max(500),
+  reason: z.string().trim().min(1, 'reason is required').max(500),
 });
 
 export type CreateTransferDto = z.infer<typeof createTransferSchema>;

--- a/src/modules/transfers/transfers.schema.ts
+++ b/src/modules/transfers/transfers.schema.ts
@@ -23,7 +23,7 @@ export const transferItemSchema = z
   })
   .superRefine((item, ctx) => {
     if (item.item_type === 'RESOURCE') {
-      if (!item.resource_type_id) {
+      if (item.resource_type_id == null) {
         ctx.addIssue({
           code: 'custom',
           path: ['resource_type_id'],
@@ -31,7 +31,7 @@ export const transferItemSchema = z
         });
       }
 
-      if (!item.quantity) {
+      if (item.quantity == null) {
         ctx.addIssue({
           code: 'custom',
           path: ['quantity'],
@@ -39,7 +39,7 @@ export const transferItemSchema = z
         });
       }
 
-      if (item.person_id) {
+      if (item.person_id != null) {
         ctx.addIssue({
           code: 'custom',
           path: ['person_id'],
@@ -49,7 +49,7 @@ export const transferItemSchema = z
     }
 
     if (item.item_type === 'PERSON') {
-      if (!item.person_id) {
+      if (item.person_id == null) {
         ctx.addIssue({
           code: 'custom',
           path: ['person_id'],
@@ -57,7 +57,7 @@ export const transferItemSchema = z
         });
       }
 
-      if (item.resource_type_id) {
+      if (item.resource_type_id != null) {
         ctx.addIssue({
           code: 'custom',
           path: ['resource_type_id'],
@@ -65,7 +65,7 @@ export const transferItemSchema = z
         });
       }
 
-      if (item.quantity) {
+      if (item.quantity != null) {
         ctx.addIssue({
           code: 'custom',
           path: ['quantity'],

--- a/src/modules/transfers/transfers.service.ts
+++ b/src/modules/transfers/transfers.service.ts
@@ -155,6 +155,16 @@ async function applyResourceTransfer(
     resourceItems: Array<{ resource_type_id: number; quantity: number }>;
   },
 ) {
+  const aggregatedResourceItems = Array.from(
+    input.resourceItems
+      .reduce((acc, item) => {
+        const currentQuantity = acc.get(item.resource_type_id) ?? 0;
+        acc.set(item.resource_type_id, currentQuantity + item.quantity);
+        return acc;
+      }, new Map<number, number>())
+      .entries(),
+  ).map(([resource_type_id, quantity]) => ({ resource_type_id, quantity }));
+
   const logEntries: Array<{
     camp_id: number;
     resource_type_id: number;
@@ -164,7 +174,7 @@ async function applyResourceTransfer(
     description: string;
   }> = [];
 
-  for (const item of input.resourceItems) {
+  for (const item of aggregatedResourceItems) {
     const updateResult = await tx.inventory.updateMany({
       where: {
         camp_id: input.sourceCampId,
@@ -452,14 +462,35 @@ export async function completeTransfer(
 
     const resourceItems = transfer.camp_transfer_item
       .filter((item) => item.item_type === 'RESOURCE')
-      .map((item) => ({
-        resource_type_id: item.resource_type_id as number,
-        quantity: asNumber(item.quantity),
-      }));
+      .map((item) => {
+        if (item.resource_type_id == null) {
+          throw new AppError('RESOURCE items must include resource_type_id', 400);
+        }
+
+        if (item.quantity == null) {
+          throw new AppError('RESOURCE items must include quantity', 400);
+        }
+
+        const quantity = asNumber(item.quantity);
+        if (!Number.isFinite(quantity) || quantity <= 0) {
+          throw new AppError('RESOURCE item quantity must be a finite positive number', 400);
+        }
+
+        return {
+          resource_type_id: item.resource_type_id,
+          quantity,
+        };
+      });
 
     const personIds = transfer.camp_transfer_item
       .filter((item) => item.item_type === 'PERSON')
-      .map((item) => item.person_id as number);
+      .map((item) => {
+        if (item.person_id == null) {
+          throw new AppError('PERSON items must include person_id', 400);
+        }
+
+        return item.person_id;
+      });
 
     if (personIds.length > 0 && resourceItems.length === 0) {
       throw new AppError('Person transfer must include travel rations (RESOURCE items)', 400);

--- a/src/modules/transfers/transfers.service.ts
+++ b/src/modules/transfers/transfers.service.ts
@@ -282,10 +282,10 @@ export async function createTransfer(data: CreateTransferDto) {
       throw new AppError('requesting_camp and target_camp must be different', 400);
     }
 
-    await Promise.all([
+    const [requestedBy] = await Promise.all([
+      ensureUserExists(tx, data.requested_by),
       ensureCampExists(tx, data.requesting_camp),
       ensureCampExists(tx, data.target_camp),
-      ensureUserExists(tx, data.requested_by),
       ensureResourceTypesExist(tx, resourceTypeIds),
       ensurePeopleExistInSourceCamp(tx, personIds, data.requesting_camp),
     ]);
@@ -293,8 +293,6 @@ export async function createTransfer(data: CreateTransferDto) {
     if (data.leader_person_id) {
       await ensurePeopleExistInSourceCamp(tx, [data.leader_person_id], data.requesting_camp);
     }
-
-    const requestedBy = await ensureUserExists(tx, data.requested_by);
     if (requestedBy.camp_id !== data.requesting_camp) {
       throw new AppError('requested_by must belong to requesting_camp', 400);
     }

--- a/src/modules/transfers/transfers.service.ts
+++ b/src/modules/transfers/transfers.service.ts
@@ -1,1 +1,544 @@
-// TODO: implement
+import { Prisma } from '../../generated/prisma/client.js';
+import { prisma } from '../../lib/prisma.js';
+import { AppError } from '../../shared/utils/appError.js';
+import {
+  ApproveTransferSourceDto,
+  ApproveTransferTargetDto,
+  CompleteTransferDto,
+  CreateTransferDto,
+  RejectTransferDto,
+  ScheduleTransferDeliveryDto,
+} from './transfers.schema.js';
+
+type TransferTransactionClient = Prisma.TransactionClient;
+type TransferWithItems = Prisma.camp_transfersGetPayload<{
+  include: { camp_transfer_item: true };
+}>;
+
+function asNumber(value: unknown): number {
+  return Number(value);
+}
+
+function parseDateTime(value?: string): Date | undefined {
+  if (!value) return undefined;
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new AppError(`Invalid datetime value: ${value}`, 400);
+  }
+
+  return parsed;
+}
+
+function buildNotes(currentNotes: string | null, nextNote?: string): string | undefined {
+  const normalizedCurrent = currentNotes?.trim();
+  const normalizedNext = nextNote?.trim();
+
+  if (!normalizedCurrent && !normalizedNext) return undefined;
+  if (!normalizedCurrent) return normalizedNext;
+  if (!normalizedNext) return normalizedCurrent;
+
+  return `${normalizedCurrent}\n${normalizedNext}`;
+}
+
+async function ensureCampExists(tx: TransferTransactionClient, campId: number) {
+  const camp = await tx.camps.findUnique({ where: { id: campId }, select: { id: true } });
+  if (!camp) throw new AppError(`Camp not found: ${campId}`, 404);
+}
+
+async function ensureUserExists(tx: TransferTransactionClient, userId: number) {
+  const user = await tx.users.findUnique({
+    where: { id: userId },
+    select: { id: true, camp_id: true },
+  });
+  if (!user) throw new AppError(`User not found: ${userId}`, 404);
+  return user;
+}
+
+async function ensureTransferExists(
+  tx: TransferTransactionClient,
+  transferId: number,
+): Promise<TransferWithItems> {
+  const transfer = await tx.camp_transfers.findUnique({
+    where: { id: transferId },
+    include: { camp_transfer_item: true },
+  });
+
+  if (!transfer) {
+    throw new AppError(`Transfer not found: ${transferId}`, 404);
+  }
+
+  return transfer;
+}
+
+async function ensureResourceTypesExist(tx: TransferTransactionClient, resourceTypeIds: number[]) {
+  if (resourceTypeIds.length === 0) return;
+
+  const uniqueIds = Array.from(new Set(resourceTypeIds));
+  const resources = await tx.resource_type.findMany({
+    where: { id: { in: uniqueIds } },
+    select: { id: true },
+  });
+
+  if (resources.length !== uniqueIds.length) {
+    throw new AppError('One or more resource_type_id values do not exist', 404);
+  }
+}
+
+async function ensurePeopleExistInSourceCamp(
+  tx: TransferTransactionClient,
+  personIds: number[],
+  sourceCampId: number,
+) {
+  if (personIds.length === 0) return;
+
+  const uniqueIds = Array.from(new Set(personIds));
+  const people = await tx.persons.findMany({
+    where: { id: { in: uniqueIds } },
+    select: { id: true, camp_id: true, status: true },
+  });
+
+  if (people.length !== uniqueIds.length) {
+    throw new AppError('One or more person_id values do not exist', 404);
+  }
+
+  for (const person of people) {
+    if (person.camp_id !== sourceCampId) {
+      throw new AppError(`Person ${person.id} does not belong to source camp ${sourceCampId}`, 400);
+    }
+
+    if (person.status === 'DEAD') {
+      throw new AppError(`Person ${person.id} cannot be transferred (status DEAD)`, 400);
+    }
+  }
+}
+
+function ensureTransferStatus(
+  transfer: TransferWithItems,
+  expectedStatus: 'PENDING' | 'APPROVED_SOURCE' | 'APPROVED_TARGET',
+) {
+  if (transfer.status !== expectedStatus) {
+    throw new AppError(
+      `Transfer ${transfer.id} must be ${expectedStatus} to perform this action. Current status: ${transfer.status}`,
+      400,
+    );
+  }
+}
+
+function ensureScheduledDeliveryDateForApproval(date: Date | null) {
+  if (!date) {
+    throw new AppError('scheduled_delivery_date is required before approval', 400);
+  }
+
+  if (date.getTime() < Date.now()) {
+    throw new AppError('scheduled_delivery_date cannot be in the past for approval', 400);
+  }
+}
+
+function ensureTransferCanBeRejected(currentStatus: string) {
+  if (currentStatus === 'COMPLETED') {
+    throw new AppError('Completed transfer cannot be rejected', 400);
+  }
+
+  if (currentStatus === 'REJECTED') {
+    throw new AppError('Transfer is already rejected', 400);
+  }
+}
+
+async function applyResourceTransfer(
+  tx: TransferTransactionClient,
+  input: {
+    transferId: number;
+    sourceCampId: number;
+    targetCampId: number;
+    completedBy: number;
+    resourceItems: Array<{ resource_type_id: number; quantity: number }>;
+  },
+) {
+  for (const item of input.resourceItems) {
+    const updateResult = await tx.inventory.updateMany({
+      where: {
+        camp_id: input.sourceCampId,
+        resource_type_id: item.resource_type_id,
+        quantity: { gte: item.quantity },
+      },
+      data: {
+        quantity: { decrement: item.quantity },
+        last_updated: new Date(),
+      },
+    });
+
+    if (updateResult.count === 0) {
+      throw new AppError(
+        `Insufficient inventory in source camp for resource_type_id ${item.resource_type_id}`,
+        400,
+      );
+    }
+
+    await tx.inventory.upsert({
+      where: {
+        camp_id_resource_type_id: {
+          camp_id: input.targetCampId,
+          resource_type_id: item.resource_type_id,
+        },
+      },
+      update: {
+        quantity: { increment: item.quantity },
+        last_updated: new Date(),
+      },
+      create: {
+        camp_id: input.targetCampId,
+        resource_type_id: item.resource_type_id,
+        quantity: item.quantity,
+      },
+    });
+
+    await tx.inventory_log.createMany({
+      data: [
+        {
+          camp_id: input.sourceCampId,
+          resource_type_id: item.resource_type_id,
+          logged_by: input.completedBy,
+          log_type: 'TRANSFER_OUT',
+          delta: -item.quantity,
+          description: `Transfer #${input.transferId} completed (source outflow)`,
+        },
+        {
+          camp_id: input.targetCampId,
+          resource_type_id: item.resource_type_id,
+          logged_by: input.completedBy,
+          log_type: 'TRANSFER_IN',
+          delta: item.quantity,
+          description: `Transfer #${input.transferId} completed (target inflow)`,
+        },
+      ],
+    });
+  }
+}
+
+async function applyPeopleTransfer(
+  tx: TransferTransactionClient,
+  input: {
+    transferId: number;
+    sourceCampId: number;
+    targetCampId: number;
+    personIds: number[];
+    personStatus: 'SICK' | 'HEALTHY' | 'INJURED' | 'AWAY' | 'DEAD';
+    changedBy: number;
+  },
+) {
+  if (input.personIds.length === 0) return;
+
+  const people = await tx.persons.findMany({
+    where: { id: { in: input.personIds } },
+    select: { id: true, camp_id: true, status: true },
+  });
+
+  if (people.length !== input.personIds.length) {
+    throw new AppError('One or more transfer people do not exist', 404);
+  }
+
+  for (const person of people) {
+    if (person.camp_id !== input.sourceCampId) {
+      throw new AppError(
+        `Person ${person.id} no longer belongs to source camp ${input.sourceCampId}`,
+        400,
+      );
+    }
+
+    await tx.persons.update({
+      where: { id: person.id },
+      data: {
+        camp_id: input.targetCampId,
+        status: input.personStatus,
+      },
+    });
+
+    if (person.status !== input.personStatus) {
+      await tx.person_status_log.create({
+        data: {
+          person_id: person.id,
+          old_status: person.status,
+          new_status: input.personStatus,
+          reason: `Transfer #${input.transferId} completed`,
+          changed_by: input.changedBy,
+        },
+      });
+    }
+  }
+}
+
+export async function createTransfer(data: CreateTransferDto) {
+  const scheduledDeliveryDate = parseDateTime(data.scheduled_delivery_date);
+  const resourceTypeIds = data.items
+    .filter((item) => item.item_type === 'RESOURCE')
+    .map((item) => item.resource_type_id as number);
+  const personIds = data.items
+    .filter((item) => item.item_type === 'PERSON')
+    .map((item) => item.person_id as number);
+
+  return prisma.$transaction(async (tx: TransferTransactionClient) => {
+    if (data.requesting_camp === data.target_camp) {
+      throw new AppError('requesting_camp and target_camp must be different', 400);
+    }
+
+    await Promise.all([
+      ensureCampExists(tx, data.requesting_camp),
+      ensureCampExists(tx, data.target_camp),
+      ensureUserExists(tx, data.requested_by),
+      ensureResourceTypesExist(tx, resourceTypeIds),
+      ensurePeopleExistInSourceCamp(tx, personIds, data.requesting_camp),
+    ]);
+
+    if (data.leader_person_id) {
+      await ensurePeopleExistInSourceCamp(tx, [data.leader_person_id], data.requesting_camp);
+    }
+
+    const requestedBy = await ensureUserExists(tx, data.requested_by);
+    if (requestedBy.camp_id !== data.requesting_camp) {
+      throw new AppError('requested_by must belong to requesting_camp', 400);
+    }
+
+    const transfer = await tx.camp_transfers.create({
+      data: {
+        requesting_camp: data.requesting_camp,
+        target_camp: data.target_camp,
+        status: 'PENDING',
+        type: data.type,
+        notes: data.notes?.trim(),
+        requested_by: data.requested_by,
+        leader_person_id: data.leader_person_id,
+        scheduled_delivery_date: scheduledDeliveryDate,
+      },
+    });
+
+    await tx.camp_transfer_item.createMany({
+      data: data.items.map((item) => ({
+        camp_transfer_id: transfer.id,
+        item_type: item.item_type,
+        resource_type_id: item.resource_type_id,
+        person_id: item.person_id,
+        quantity: item.item_type === 'RESOURCE' ? item.quantity : null,
+      })),
+    });
+
+    return tx.camp_transfers.findUnique({
+      where: { id: transfer.id },
+      include: { camp_transfer_item: true },
+    });
+  });
+}
+
+export async function scheduleTransferDelivery(
+  transferId: number,
+  actorUserId: number,
+  data: ScheduleTransferDeliveryDto,
+) {
+  const scheduledDeliveryDate = parseDateTime(data.scheduled_delivery_date)!;
+
+  if (scheduledDeliveryDate.getTime() < Date.now()) {
+    throw new AppError('scheduled_delivery_date cannot be in the past', 400);
+  }
+
+  return prisma.$transaction(async (tx: TransferTransactionClient) => {
+    const actor = await ensureUserExists(tx, actorUserId);
+    const transfer = await ensureTransferExists(tx, transferId);
+
+    if (transfer.status === 'COMPLETED' || transfer.status === 'REJECTED') {
+      throw new AppError('Cannot schedule delivery for completed or rejected transfers', 400);
+    }
+
+    if (actor.camp_id !== transfer.requesting_camp) {
+      throw new AppError('Only requesting camp can schedule delivery date', 403);
+    }
+
+    return tx.camp_transfers.update({
+      where: { id: transferId },
+      data: { scheduled_delivery_date: scheduledDeliveryDate },
+      include: { camp_transfer_item: true },
+    });
+  });
+}
+
+export async function approveTransferBySource(
+  transferId: number,
+  approverUserId: number,
+  data: ApproveTransferSourceDto,
+) {
+  const scheduledDeliveryDate = parseDateTime(data.scheduled_delivery_date);
+
+  return prisma.$transaction(async (tx: TransferTransactionClient) => {
+    const approver = await ensureUserExists(tx, approverUserId);
+    const transfer = await ensureTransferExists(tx, transferId);
+
+    ensureTransferStatus(transfer, 'PENDING');
+
+    if (approver.camp_id !== transfer.requesting_camp) {
+      throw new AppError('Only requesting camp can approve source stage', 403);
+    }
+
+    const effectiveScheduledDate = scheduledDeliveryDate ?? transfer.scheduled_delivery_date;
+    ensureScheduledDeliveryDateForApproval(effectiveScheduledDate);
+
+    return tx.camp_transfers.update({
+      where: { id: transferId },
+      data: {
+        status: 'APPROVED_SOURCE',
+        approved_by_source: approverUserId,
+        approved_source_at: new Date(),
+        scheduled_delivery_date: effectiveScheduledDate,
+        notes: buildNotes(transfer.notes, data.notes),
+      },
+      include: { camp_transfer_item: true },
+    });
+  });
+}
+
+export async function approveTransferByTarget(
+  transferId: number,
+  approverUserId: number,
+  data: ApproveTransferTargetDto,
+) {
+  return prisma.$transaction(async (tx: TransferTransactionClient) => {
+    const approver = await ensureUserExists(tx, approverUserId);
+    const transfer = await ensureTransferExists(tx, transferId);
+
+    ensureTransferStatus(transfer, 'APPROVED_SOURCE');
+
+    if (approver.camp_id !== transfer.target_camp) {
+      throw new AppError('Only target camp can approve target stage', 403);
+    }
+
+    ensureScheduledDeliveryDateForApproval(transfer.scheduled_delivery_date);
+
+    return tx.camp_transfers.update({
+      where: { id: transferId },
+      data: {
+        status: 'APPROVED_TARGET',
+        approved_by_target: approverUserId,
+        approved_target_at: new Date(),
+        notes: buildNotes(transfer.notes, data.notes),
+      },
+      include: { camp_transfer_item: true },
+    });
+  });
+}
+
+export async function completeTransfer(
+  transferId: number,
+  completedBy: number,
+  data: CompleteTransferDto,
+) {
+  const targetPersonStatus = data.person_status ?? 'HEALTHY';
+
+  return prisma.$transaction(async (tx: TransferTransactionClient) => {
+    const actor = await ensureUserExists(tx, completedBy);
+    const transfer = await ensureTransferExists(tx, transferId);
+
+    ensureTransferStatus(transfer, 'APPROVED_TARGET');
+
+    if (actor.camp_id !== transfer.requesting_camp && actor.camp_id !== transfer.target_camp) {
+      throw new AppError('Only source or target camp users can complete transfer', 403);
+    }
+
+    const resourceItems = transfer.camp_transfer_item
+      .filter((item) => item.item_type === 'RESOURCE')
+      .map((item) => ({
+        resource_type_id: item.resource_type_id as number,
+        quantity: asNumber(item.quantity),
+      }));
+
+    const personIds = transfer.camp_transfer_item
+      .filter((item) => item.item_type === 'PERSON')
+      .map((item) => item.person_id as number);
+
+    if (personIds.length > 0 && resourceItems.length === 0) {
+      throw new AppError('Person transfer must include travel rations (RESOURCE items)', 400);
+    }
+
+    await applyResourceTransfer(tx, {
+      transferId: transfer.id,
+      sourceCampId: transfer.requesting_camp,
+      targetCampId: transfer.target_camp,
+      completedBy,
+      resourceItems,
+    });
+
+    await applyPeopleTransfer(tx, {
+      transferId: transfer.id,
+      sourceCampId: transfer.requesting_camp,
+      targetCampId: transfer.target_camp,
+      personIds,
+      personStatus: targetPersonStatus,
+      changedBy: completedBy,
+    });
+
+    return tx.camp_transfers.update({
+      where: { id: transfer.id },
+      data: {
+        status: 'COMPLETED',
+        notes: buildNotes(transfer.notes, data.notes),
+      },
+      include: { camp_transfer_item: true },
+    });
+  });
+}
+
+export async function rejectTransfer(
+  transferId: number,
+  actorUserId: number,
+  data: RejectTransferDto,
+) {
+  return prisma.$transaction(async (tx: TransferTransactionClient) => {
+    const actor = await ensureUserExists(tx, actorUserId);
+    const transfer = await ensureTransferExists(tx, transferId);
+
+    ensureTransferCanBeRejected(transfer.status);
+
+    if (actor.camp_id !== transfer.requesting_camp && actor.camp_id !== transfer.target_camp) {
+      throw new AppError('Only source or target camp users can reject transfer', 403);
+    }
+
+    return tx.camp_transfers.update({
+      where: { id: transfer.id },
+      data: {
+        status: 'REJECTED',
+        notes: buildNotes(transfer.notes, `Rejected by user ${actorUserId}: ${data.reason.trim()}`),
+      },
+      include: { camp_transfer_item: true },
+    });
+  });
+}
+
+export async function getTransfer(id: number) {
+  const transfer = await prisma.camp_transfers.findUnique({
+    where: { id },
+    include: {
+      camp_transfer_item: true,
+      camps_camp_transfers_requesting_campTocamps: true,
+      camps_camp_transfers_target_campTocamps: true,
+    },
+  });
+
+  if (!transfer) {
+    throw new AppError(`Transfer not found: ${id}`, 404);
+  }
+
+  return transfer;
+}
+
+export async function getTransfers() {
+  const transfers = await prisma.camp_transfers.findMany({
+    orderBy: { created_at: 'desc' },
+    include: {
+      camp_transfer_item: true,
+      camps_camp_transfers_requesting_campTocamps: true,
+      camps_camp_transfers_target_campTocamps: true,
+    },
+  });
+
+  return {
+    total: transfers.length,
+    transfers,
+  };
+}

--- a/src/modules/transfers/transfers.service.ts
+++ b/src/modules/transfers/transfers.service.ts
@@ -155,6 +155,15 @@ async function applyResourceTransfer(
     resourceItems: Array<{ resource_type_id: number; quantity: number }>;
   },
 ) {
+  const logEntries: Array<{
+    camp_id: number;
+    resource_type_id: number;
+    logged_by: number;
+    log_type: string;
+    delta: number;
+    description: string;
+  }> = [];
+
   for (const item of input.resourceItems) {
     const updateResult = await tx.inventory.updateMany({
       where: {
@@ -193,26 +202,28 @@ async function applyResourceTransfer(
       },
     });
 
-    await tx.inventory_log.createMany({
-      data: [
-        {
-          camp_id: input.sourceCampId,
-          resource_type_id: item.resource_type_id,
-          logged_by: input.completedBy,
-          log_type: 'TRANSFER_OUT',
-          delta: -item.quantity,
-          description: `Transfer #${input.transferId} completed (source outflow)`,
-        },
-        {
-          camp_id: input.targetCampId,
-          resource_type_id: item.resource_type_id,
-          logged_by: input.completedBy,
-          log_type: 'TRANSFER_IN',
-          delta: item.quantity,
-          description: `Transfer #${input.transferId} completed (target inflow)`,
-        },
-      ],
-    });
+    logEntries.push(
+      {
+        camp_id: input.sourceCampId,
+        resource_type_id: item.resource_type_id,
+        logged_by: input.completedBy,
+        log_type: 'TRANSFER_OUT',
+        delta: -item.quantity,
+        description: `Transfer #${input.transferId} completed (source outflow)`,
+      },
+      {
+        camp_id: input.targetCampId,
+        resource_type_id: item.resource_type_id,
+        logged_by: input.completedBy,
+        log_type: 'TRANSFER_IN',
+        delta: item.quantity,
+        description: `Transfer #${input.transferId} completed (target inflow)`,
+      },
+    );
+  }
+
+  if (logEntries.length > 0) {
+    await tx.inventory_log.createMany({ data: logEntries });
   }
 }
 


### PR DESCRIPTION
This pull request introduces the transfers module, which enables API support for camp-to-camp transfers of resources and people. It includes new routes, controller logic, validation schemas, and seed data for transfers. The changes ensure robust validation, proper API structure, and initial test data for development and testing.

**Transfers Module Implementation**

* Added the `/api/transfers` route and integrated it into the main Express app, protected by authentication, session, and camp middlewares. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R22) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R42)
* Implemented the `transfers.controller.ts` with handlers for creating, listing, retrieving, scheduling, approving, completing, and rejecting transfers.
* Created `transfers.routes.ts` defining RESTful endpoints for all major transfer actions, each with appropriate validation using Zod schemas.

**Validation and Schema Enhancements**

* Significantly expanded `transfers.schema.ts` to:
  - Enforce strict rules on transfer creation (e.g., item type consistency, required rations for person transfers, no duplicate items, etc.).
  - Add schemas for each transfer action (scheduling, approvals, completion, rejection).
  - Add a `personStatusEnum` and improved date-time validation. [[1]](diffhunk://#diff-5d043e89f51dd393c547c944c13f5f632fa6aec83772fd8f898148b832efe9e1R13-R15) [[2]](diffhunk://#diff-5d043e89f51dd393c547c944c13f5f632fa6aec83772fd8f898148b832efe9e1R34-R41) [[3]](diffhunk://#diff-5d043e89f51dd393c547c944c13f5f632fa6aec83772fd8f898148b832efe9e1R67-R188)

**Seed Data for Transfers**

* Extended the Prisma seed script to populate the database with several example transfers in various states (pending, approved, rejected) and their associated items, supporting both resource and person transfers.

**Other Minor Changes**

* Added "Tocamps" to the spellchecker dictionary.