### PR TITLE
Include user role in login response and update Swagger documentation

### DIFF
--- a/src/docs/swagger.ts
+++ b/src/docs/swagger.ts
@@ -67,9 +67,10 @@ export const swaggerSpec = swaggerJSDoc({
           properties: {
             user: {
               type: 'object',
-              required: ['username'],
+              required: ['username', 'role'],
               properties: {
                 username: { type: 'string', example: 'admin' },
+                role: { type: 'string', example: 'worker' },
               },
             },
             token: {

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -7,6 +7,7 @@ import { signAccessToken } from '../../shared/utils/jwt.js';
 export const login = async (data: LoginInput) => {
   const user = await prisma.users.findUnique({
     where: { username: data.username },
+    include: { roles: { select: { name: true } } },
   });
 
   if (!user) {
@@ -20,5 +21,8 @@ export const login = async (data: LoginInput) => {
 
   const token = signAccessToken(user.id, user.camp_id);
 
-  return { user: { username: user.username }, token };
+  return {
+    user: { username: user.username, role: user.roles.name },
+    token,
+  };
 };


### PR DESCRIPTION
This pull request updates the authentication logic and API documentation to include user roles in the login response. The main changes ensure that the user's role is returned upon login and that the API docs accurately reflect this new response structure.

**Authentication logic update:**

* The `login` function in `auth.service.ts` now fetches the user's role from the database and includes it in the returned user object. [[1]](diffhunk://#diff-fdfdc5f661ae4e2563a2e95285b88812b78ee43f05fc95bb88ba319759981116R10) [[2]](diffhunk://#diff-fdfdc5f661ae4e2563a2e95285b88812b78ee43f05fc95bb88ba319759981116L23-R27)

**API documentation update:**

* The Swagger specification in `swagger.ts` has been updated to require the `role` field in the login response and provide an example value.