### PR TITLE
Add Supabase connection and fix README and environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,25 +2,32 @@
 NODE_ENV=development
 PORT=3000
 
-# Database
+# ─── Database (Local - Docker Compose) ───────────────────────────────────────
+# Used when building DATABASE_URL manually from individual variables
 DB_HOST=localhost
 DB_PORT=5432
 DB_USER=postgres
 DB_PASSWORD=secret
 DB_NAME=gestion_del_fin
 
-# Keep URLs for Prisma CLI (Migrations)
+# ─── Database URLs ────────────────────────────────────────────────────────────
+# Runtime connection (Session Pooler for Supabase, or local PostgreSQL)
 DATABASE_URL="postgresql://<user>:<password>@<host>:<port>/<database>"
-DATABASE_MIGRATION_URL="postgresql://<migration_user>:<migration_password>@<host>:<port>/<database>"
+
+# Direct connection — used by Prisma CLI for migrations (Supabase: use Direct Connection URL)
+DATABASE_DIRECT_URL="postgresql://<user>:<password>@<host>:<port>/<database>"
+
+# Shadow database — optional, only needed for prisma migrate dev locally
 SHADOW_DATABASE_URL="postgresql://<user>:<password>@<host>:<port>/<shadow_database>"
 
-# Gemini-AI
-GEMINI-API-KEY=your_hyper_secret_gemini_api_key
+# ─── Gemini AI ────────────────────────────────────────────────────────────────
+GROQ_API_KEY=your_groq_api_key_here
 
-# JWT (min 32 characters)
+# ─── JWT ──────────────────────────────────────────────────────────────────────
+# Must be at least 32 characters
 JWT_SECRET=your-super-secret-jwt-key-with-at-least-32-characters-here
 JWT_EXPIRY=1h
 
-# Logging
+# ─── Logging ──────────────────────────────────────────────────────────────────
 LOG_LEVEL=info
 LOG_FILE=./logs/app.log

--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ DATABASE_DIRECT_URL="postgresql://<user>:<password>@<host>:<port>/<database>"
 # Shadow database — optional, only needed for prisma migrate dev locally
 SHADOW_DATABASE_URL="postgresql://<user>:<password>@<host>:<port>/<shadow_database>"
 
-# ─── Gemini AI ────────────────────────────────────────────────────────────────
+# ─── Groq AI ────────────────────────────────────────────────────────────────
 GROQ_API_KEY=your_groq_api_key_here
 
 # ─── JWT ──────────────────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -3,57 +3,56 @@
 Secure API for **Gestión del fin** (EIF209). Handles multi-camp management, resources, AI-driven ingress decisions, and audit logs. Features server-side time consistency, RBAC, 20min session security, and support for resource transfers and expeditions. Built with Node.js and TypeScript. Universidad Nacional 2026.
 
 # Database
- 
+
 This project uses **PostgreSQL** via [Supabase](https://supabase.com) in production, and a local PostgreSQL instance (via Docker Compose) for development.
- 
+
 ### Environment variables
- 
+
 Copy `.env.example` and fill in the values:
- 
+
 ```bash
 cp .env.example .env
 ```
- 
+
 For **local development**, set the database URLs to your local PostgreSQL instance:
- 
+
 ```env
 DATABASE_URL="postgresql://postgres:secret@localhost:5432/gestion_del_fin"
 DATABASE_DIRECT_URL="postgresql://postgres:secret@localhost:5432/gestion_del_fin"
 ```
- 
+
 For **production (Supabase)**, use the connection strings from your Supabase project dashboard under Project Settings → Database → Connection string:
- 
+
 ```env
 DATABASE_URL="postgresql://postgres.xxx:password@aws-x-xx.pooler.supabase.com:5432/postgres"
 DATABASE_DIRECT_URL="postgresql://postgres:password@db.xxx.supabase.co:5432/postgres"
 ```
- 
+
 ### Migrations
- 
+
 To apply migrations to the **local** database:
- 
+
 ```bash
 npx prisma migrate dev
 ```
- 
+
 To apply migrations to **Supabase** (production):
- 
+
 ```bash
 npx prisma migrate deploy
 ```
- 
+
 > Migrations are applied automatically on deploy via Railway.
- 
+
 ### Seed
- 
+
 To populate the database with initial data:
- 
+
 ```bash
 npx prisma db seed
 ```
- 
----
 
+---
 
 ## Development Setup
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,59 @@
 
 Secure API for **Gestión del fin** (EIF209). Handles multi-camp management, resources, AI-driven ingress decisions, and audit logs. Features server-side time consistency, RBAC, 20min session security, and support for resource transfers and expeditions. Built with Node.js and TypeScript. Universidad Nacional 2026.
 
+# Database
+ 
+This project uses **PostgreSQL** via [Supabase](https://supabase.com) in production, and a local PostgreSQL instance (via Docker Compose) for development.
+ 
+### Environment variables
+ 
+Copy `.env.example` and fill in the values:
+ 
+```bash
+cp .env.example .env
+```
+ 
+For **local development**, set the database URLs to your local PostgreSQL instance:
+ 
+```env
+DATABASE_URL="postgresql://postgres:secret@localhost:5432/gestion_del_fin"
+DATABASE_DIRECT_URL="postgresql://postgres:secret@localhost:5432/gestion_del_fin"
+```
+ 
+For **production (Supabase)**, use the connection strings from your Supabase project dashboard under Project Settings → Database → Connection string:
+ 
+```env
+DATABASE_URL="postgresql://postgres.xxx:password@aws-x-xx.pooler.supabase.com:5432/postgres"
+DATABASE_DIRECT_URL="postgresql://postgres:password@db.xxx.supabase.co:5432/postgres"
+```
+ 
+### Migrations
+ 
+To apply migrations to the **local** database:
+ 
+```bash
+npx prisma migrate dev
+```
+ 
+To apply migrations to **Supabase** (production):
+ 
+```bash
+npx prisma migrate deploy
+```
+ 
+> Migrations are applied automatically on deploy via Railway.
+ 
+### Seed
+ 
+To populate the database with initial data:
+ 
+```bash
+npx prisma db seed
+```
+ 
+---
+
+
 ## Development Setup
 
 This project can be run using either **manual Node setup** (recommended) or **Nix**.

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     seed: 'tsx prisma/seed.ts',
   },
   datasource: {
-    url: process.env['DATABASE_MIGRATION_URL'] ?? process.env['DATABASE_URL'],
+    url: process.env['DATABASE_URL'],
     shadowDatabaseUrl: process.env['SHADOW_DATABASE_URL'],
   },
 });

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -19,6 +19,6 @@ const getConnectionUrl = (): string => {
 
 // Create Prisma Client with PostgreSQL adapter
 const adapter = new PrismaPg({ connectionString: getConnectionUrl() });
-const prisma = new PrismaClient({ adapter });
 
-export { prisma };
+export const prisma = new PrismaClient({ adapter });
+

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -21,4 +21,3 @@ const getConnectionUrl = (): string => {
 const adapter = new PrismaPg({ connectionString: getConnectionUrl() });
 
 export const prisma = new PrismaClient({ adapter });
-


### PR DESCRIPTION
This pull request refines the project's database configuration to better support both local development and production environments, particularly with PostgreSQL and Supabase. It clarifies environment variable usage, updates documentation for setup and migrations, and simplifies how Prisma connects to the database.

**Database configuration and documentation improvements:**

* Expanded and clarified the `.env.example` file with grouped sections, new variables (`DATABASE_DIRECT_URL`, `GROQ_API_KEY`), and detailed comments to distinguish between local and production (Supabase) setups.
* Updated `README.md` with clear instructions for configuring database environment variables, running migrations, and seeding data for both local and Supabase environments.

**Prisma setup simplification:**

* Changed `prisma.config.ts` to always use `DATABASE_URL` for the datasource, removing the now-unused `DATABASE_MIGRATION_URL` variable.
* Updated `src/lib/prisma.ts` to export the `prisma` client directly as a named export, improving code clarity and consistency.