### PR TITLE
Update README and admission_ai documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,21 @@ The admission system uses a Python microservice that runs a Decision Tree Classi
 
 > See [admission_ai.md](./docs/admission_ai.md) for full documentation on how the AI admission system works.
 
+
+### Installing Python dependencies
+ 
+**With Nix** — dependencies are provided automatically by the flake, no extra steps needed.
+ 
+**Without Nix** — install manually using a virtual environment:
+ 
+```bash
+cd ml-service
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+
 ### Running the ML service locally
 
 In a separate terminal from your API:

--- a/README.md
+++ b/README.md
@@ -162,20 +162,18 @@ The admission system uses a Python microservice that runs a Decision Tree Classi
 
 > See [admission_ai.md](./docs/admission_ai.md) for full documentation on how the AI admission system works.
 
-
 ### Installing Python dependencies
- 
+
 **With Nix** — dependencies are provided automatically by the flake, no extra steps needed.
- 
+
 **Without Nix** — install manually using a virtual environment:
- 
+
 ```bash
 cd ml-service
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 ```
-
 
 ### Running the ML service locally
 

--- a/docs/admission_ai.md
+++ b/docs/admission_ai.md
@@ -112,20 +112,18 @@ REJECTED          0.89    1.00      0.94
 
 The model has perfect recall on REJECTED — it never lets through someone who should be rejected. This is the desired behavior for a post-apocalyptic camp security context.
 
-
 ### Installing Python dependencies
- 
+
 **With Nix** — dependencies are provided automatically by the flake.
- 
+
 **Without Nix** — use a virtual environment:
- 
+
 ```bash
 cd ml-service
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
 ```
-
 
 ### Running the trainer
 

--- a/docs/admission_ai.md
+++ b/docs/admission_ai.md
@@ -112,6 +112,21 @@ REJECTED          0.89    1.00      0.94
 
 The model has perfect recall on REJECTED — it never lets through someone who should be rejected. This is the desired behavior for a post-apocalyptic camp security context.
 
+
+### Installing Python dependencies
+ 
+**With Nix** — dependencies are provided automatically by the flake.
+ 
+**Without Nix** — use a virtual environment:
+ 
+```bash
+cd ml-service
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+
 ### Running the trainer
 
 ```bash


### PR DESCRIPTION
This pull request improves the documentation for setting up Python dependencies for the AI admission system. Clear instructions are now provided for both Nix and non-Nix environments to help users install the required Python packages.

Dependency installation documentation:

* Added a new "Installing Python dependencies" section to both `README.md` and `docs/admission_ai.md`, with step-by-step instructions for setting up a Python virtual environment and installing dependencies using `pip` if not using Nix. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R165-R177) [[2]](diffhunk://#diff-36a891b0086c0ffc98210e6f37c4e684da8270e55acdedc88336a4599bb6f1aaR115-R127)