### PR TITLE
Include ordered person_status_log in getPerson

### DIFF
--- a/src/modules/people/people.service.ts
+++ b/src/modules/people/people.service.ts
@@ -222,7 +222,15 @@ export async function updatePerson(
 }
 
 export async function getPerson(campId: number, id: number) {
-  const person = await prisma.persons.findUnique({ where: { id }, include: personInclude });
+  const person = await prisma.persons.findUnique({
+    where: { id },
+    include: {
+      ...personInclude,
+      person_status_log: {
+        orderBy: { changed_at: 'desc' },
+      },
+    },
+  });
   if (!person) {
     throw new AppError(`Person not found: ${id}`, 404);
   }


### PR DESCRIPTION
Return person_status_log when fetching a person and order entries by changed_at descending. Merges the new relation into the existing personInclude in prisma.findUnique so the person's status history is included with the most recent changes first.