### PR TITLE
Fix prisma.config issues

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,11 +1,5 @@
 import { defineConfig } from 'prisma/config';
 
-// Only load dotenv in non-production environments
-if (process.env.NODE_ENV !== 'production') {
-  const { config } = await import('dotenv');
-  config();
-}
-
 export default defineConfig({
   schema: 'prisma/schema.prisma',
   migrations: {


### PR DESCRIPTION
This pull request removes the code that conditionally loads environment variables from `.env` files in non-production environments from the `prisma.config.ts` file. This means dotenv will no longer be loaded automatically when running Prisma commands in development or test environments.