### PR TITLE
Replace bcryptjs with @node-rs/bcrypt for native performance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ model: claude
 | **Runtime**       | Node.js 20+, Express 5.2.1     | `/src/index.ts` is entry; 13 route modules mounted                         |
 | **Language**      | TypeScript (strict mode)       | Compiles to `/dist`, runs via `node` or `tsx watch`                        |
 | **Database**      | PostgreSQL + Prisma 7.8        | Schema in `/prisma/schema.prisma`; migrations in `/prisma/migrations/`     |
-| **Auth**          | JWT (jsonwebtoken), bcryptjs   | 20-min session timeout via `session.middleware.ts`                         |
+| **Auth**          | JWT (jsonwebtoken), @node-rs/bcrypt | 20-min session timeout via `session.middleware.ts`                         |
 | **Validation**    | Zod                            | schemas in `{module}.schema.ts`; applied via `validate(Schema)` middleware |
 | **Logging**       | Winston                        | general logs + daily rotate; audit log captures user actions               |
 | **Job Scheduler** | node-cron                      | daily-rations, resource-alerts jobs in `/src/jobs/`                        |

--- a/docs/core.md
+++ b/docs/core.md
@@ -24,7 +24,7 @@ Think of it as a **management system for coordinating survival camps**: tracking
 ### Security & Auth
 
 - **JWT (jsonwebtoken)** - Creates secure tokens so users don't have to log in every request
-- **bcryptjs** - Hashes passwords securely (never stores plain passwords)
+- **@node-rs/bcrypt** - Native Rust bcrypt implementation for secure password hashing
 - **Helmet** - Adds security headers to HTTP responses
 - **CORS** - Controls which domains can access our API
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@node-rs/bcrypt": "^1.10.7",
         "@prisma/adapter-pg": "^7.8.0",
         "@prisma/client": "^7.8.0",
-        "bcryptjs": "^3.0.3",
         "cors": "^2.8.6",
         "date-fns": "^4.1.0",
         "date-fns-tz": "^3.2.0",
@@ -33,7 +33,6 @@
       "devDependencies": {
         "@faker-js/faker": "^10.4.0",
         "@playwright/test": "^1.58.2",
-        "@types/bcryptjs": "^2.4.6",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "@types/jest": "^30.0.0",
@@ -1085,6 +1084,37 @@
         "@electric-sql/pglite": "0.4.1"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.27.3",
       "cpu": [
@@ -1996,6 +2026,271 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@node-rs/bcrypt": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt/-/bcrypt-1.10.7.tgz",
+      "integrity": "sha512-1wk0gHsUQC/ap0j6SJa2K34qNhomxXRcEe3T8cI5s+g6fgHBgLTN7U9LzWTG/HE6G4+2tWWLeCabk1wiYGEQSA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@node-rs/bcrypt-android-arm-eabi": "1.10.7",
+        "@node-rs/bcrypt-android-arm64": "1.10.7",
+        "@node-rs/bcrypt-darwin-arm64": "1.10.7",
+        "@node-rs/bcrypt-darwin-x64": "1.10.7",
+        "@node-rs/bcrypt-freebsd-x64": "1.10.7",
+        "@node-rs/bcrypt-linux-arm-gnueabihf": "1.10.7",
+        "@node-rs/bcrypt-linux-arm64-gnu": "1.10.7",
+        "@node-rs/bcrypt-linux-arm64-musl": "1.10.7",
+        "@node-rs/bcrypt-linux-x64-gnu": "1.10.7",
+        "@node-rs/bcrypt-linux-x64-musl": "1.10.7",
+        "@node-rs/bcrypt-wasm32-wasi": "1.10.7",
+        "@node-rs/bcrypt-win32-arm64-msvc": "1.10.7",
+        "@node-rs/bcrypt-win32-ia32-msvc": "1.10.7",
+        "@node-rs/bcrypt-win32-x64-msvc": "1.10.7"
+      }
+    },
+    "node_modules/@node-rs/bcrypt-android-arm-eabi": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-android-arm-eabi/-/bcrypt-android-arm-eabi-1.10.7.tgz",
+      "integrity": "sha512-8dO6/PcbeMZXS3VXGEtct9pDYdShp2WBOWlDvSbcRwVqyB580aCBh0BEFmKYtXLzLvUK8Wf+CG3U6sCdILW1lA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/bcrypt-android-arm64": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-android-arm64/-/bcrypt-android-arm64-1.10.7.tgz",
+      "integrity": "sha512-UASFBS/CucEMHiCtL/2YYsAY01ZqVR1N7vSb94EOvG5iwW7BQO06kXXCTgj+Xbek9azxixrCUmo3WJnkJZ0hTQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/bcrypt-darwin-arm64": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-darwin-arm64/-/bcrypt-darwin-arm64-1.10.7.tgz",
+      "integrity": "sha512-DgzFdAt455KTuiJ/zYIyJcKFobjNDR/hnf9OS7pK5NRS13Nq4gLcSIIyzsgHwZHxsJWbLpHmFc1H23Y7IQoQBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/bcrypt-darwin-x64": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-darwin-x64/-/bcrypt-darwin-x64-1.10.7.tgz",
+      "integrity": "sha512-SPWVfQ6sxSokoUWAKWD0EJauvPHqOGQTd7CxmYatcsUgJ/bruvEHxZ4bIwX1iDceC3FkOtmeHO0cPwR480n/xA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/bcrypt-freebsd-x64": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-freebsd-x64/-/bcrypt-freebsd-x64-1.10.7.tgz",
+      "integrity": "sha512-gpa+Ixs6GwEx6U6ehBpsQetzUpuAGuAFbOiuLB2oo4N58yU4AZz1VIcWyWAHrSWRs92O0SHtmo2YPrMrwfBbSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/bcrypt-linux-arm-gnueabihf": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-linux-arm-gnueabihf/-/bcrypt-linux-arm-gnueabihf-1.10.7.tgz",
+      "integrity": "sha512-kYgJnTnpxrzl9sxYqzflobvMp90qoAlaX1oDL7nhNTj8OYJVDIk0jQgblj0bIkjmoPbBed53OJY/iu4uTS+wig==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/bcrypt-linux-arm64-gnu": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-linux-arm64-gnu/-/bcrypt-linux-arm64-gnu-1.10.7.tgz",
+      "integrity": "sha512-7cEkK2RA+gBCj2tCVEI1rDSJV40oLbSq7bQ+PNMHNI6jCoXGmj9Uzo7mg7ZRbNZ7piIyNH5zlJqutjo8hh/tmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/bcrypt-linux-arm64-musl": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-linux-arm64-musl/-/bcrypt-linux-arm64-musl-1.10.7.tgz",
+      "integrity": "sha512-X7DRVjshhwxUqzdUKDlF55cwzh+wqWJ2E/tILvZPboO3xaNO07Um568Vf+8cmKcz+tiZCGP7CBmKbBqjvKN/Pw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/bcrypt-linux-x64-gnu": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-linux-x64-gnu/-/bcrypt-linux-x64-gnu-1.10.7.tgz",
+      "integrity": "sha512-LXRZsvG65NggPD12hn6YxVgH0W3VR5fsE/o1/o2D5X0nxKcNQGeLWnRzs5cP8KpoFOuk1ilctXQJn8/wq+Gn/Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/bcrypt-linux-x64-musl": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-linux-x64-musl/-/bcrypt-linux-x64-musl-1.10.7.tgz",
+      "integrity": "sha512-tCjHmct79OfcO3g5q21ME7CNzLzpw1MAsUXCLHLGWH+V6pp/xTvMbIcLwzkDj6TI3mxK6kehTn40SEjBkZ3Rog==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/bcrypt-wasm32-wasi": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-wasm32-wasi/-/bcrypt-wasm32-wasi-1.10.7.tgz",
+      "integrity": "sha512-4qXSihIKeVXYglfXZEq/QPtYtBUvR8d3S85k15Lilv3z5B6NSGQ9mYiNleZ7QHVLN2gEc5gmi7jM353DMH9GkA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@node-rs/bcrypt-win32-arm64-msvc": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-win32-arm64-msvc/-/bcrypt-win32-arm64-msvc-1.10.7.tgz",
+      "integrity": "sha512-FdfUQrqmDfvC5jFhntMBkk8EI+fCJTx/I1v7Rj+Ezlr9rez1j1FmuUnywbBj2Cg15/0BDhwYdbyZ5GCMFli2aQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/bcrypt-win32-ia32-msvc": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-win32-ia32-msvc/-/bcrypt-win32-ia32-msvc-1.10.7.tgz",
+      "integrity": "sha512-lZLf4Cx+bShIhU071p5BZft4OvP4PGhyp542EEsb3zk34U5GLsGIyCjOafcF/2DGewZL6u8/aqoxbSuROkgFXg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/bcrypt-win32-x64-msvc": {
+      "version": "1.10.7",
+      "resolved": "https://registry.npmjs.org/@node-rs/bcrypt-win32-x64-msvc/-/bcrypt-win32-x64-msvc-1.10.7.tgz",
+      "integrity": "sha512-hdw7tGmN1DxVAMTzICLdaHpXjy+4rxaxnBMgI8seG1JL5e3VcRGsd1/1vVDogVp2cbsmgq+6d6yAY+D9lW/DCg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "dev": true,
@@ -2461,6 +2756,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "dev": true,
@@ -2497,11 +2802,6 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
-    },
-    "node_modules/@types/bcryptjs": {
-      "version": "2.4.6",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -3249,13 +3549,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/bcryptjs": {
-      "version": "3.0.3",
-      "license": "BSD-3-Clause",
-      "bin": {
-        "bcrypt": "bin/bcrypt"
       }
     },
     "node_modules/body-parser": {
@@ -8655,6 +8948,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   "author": "Matteo Quesada",
   "license": "ISC",
   "dependencies": {
+    "@node-rs/bcrypt": "^1.10.7",
     "@prisma/adapter-pg": "^7.8.0",
     "@prisma/client": "^7.8.0",
-    "bcryptjs": "^3.0.3",
     "cors": "^2.8.6",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
@@ -51,7 +51,6 @@
   "devDependencies": {
     "@faker-js/faker": "^10.4.0",
     "@playwright/test": "^1.58.2",
-    "@types/bcryptjs": "^2.4.6",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/jest": "^30.0.0",

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,6 +1,6 @@
 import { prisma } from '../../lib/prisma.js';
 import { AppError } from '../../shared/utils/appError.js';
-import bcrypt from 'bcryptjs';
+import { compare } from '@node-rs/bcrypt';
 import { LoginInput } from './auth.schema.js';
 import { signAccessToken } from '../../shared/utils/jwt.js';
 import { PERMISSIONS } from '../../shared/constants/permissions.js';
@@ -37,7 +37,7 @@ export const login = async (data: LoginInput) => {
     throw new AppError('User has no role assigned', 500);
   }
 
-  const isPasswordValid = await bcrypt.compare(data.password, user.password_hash);
+  const isPasswordValid = await compare(data.password, user.password_hash);
   if (!isPasswordValid) {
     throw new AppError('Invalid credentials', 401);
   }

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -3,12 +3,12 @@ import { AppError } from '../../shared/utils/appError.js';
 import { handleUniqueConstraintError } from '../../shared/utils/handlePrismaError.js';
 import { CreateUserDto, UpdateUserDto } from './users.schema.js';
 import { auditLog } from '../../shared/utils/auditLog.js';
-import bcrypt from 'bcryptjs';
+import { hash } from '@node-rs/bcrypt';
 
 const SALT_ROUNDS = parseInt(process.env.BCRYPT_SALT_ROUNDS || '10', 10);
 
 async function prepareUserCreateData(data: CreateUserDto) {
-  const password_hash = await bcrypt.hash(data.password, SALT_ROUNDS);
+  const password_hash = await hash(data.password, SALT_ROUNDS);
 
   return {
     username: data.username.trim(),
@@ -22,7 +22,7 @@ async function prepareUserCreateData(data: CreateUserDto) {
 }
 
 async function prepareUserUpdateData(data: UpdateUserDto) {
-  const password_hash = data.password ? await bcrypt.hash(data.password, SALT_ROUNDS) : undefined;
+  const password_hash = data.password ? await hash(data.password, SALT_ROUNDS) : undefined;
 
   return {
     username: data.username?.trim(),

--- a/tests/e2e/global.setup.ts
+++ b/tests/e2e/global.setup.ts
@@ -23,7 +23,7 @@ async function globalSetup(): Promise<void> {
   const { prisma } = await import('../../src/lib/prisma.js');
   const { PERMISSIONS } = await import('../../src/shared/constants/permissions.js');
   const { signAccessToken } = await import('../../src/shared/utils/jwt.js');
-  const bcrypt = (await import('bcryptjs')).default;
+  const { hash } = await import('@node-rs/bcrypt');
   const fsMod = await import('fs');
 
   // ─── Phase 1: Clean slate ────────────────────────────────────────────
@@ -159,7 +159,7 @@ async function globalSetup(): Promise<void> {
   console.log('Setup: 2 professions created');
 
   // ─── Phase 3: Create test users ───────────────────────────────────────
-  const passwordHash = await bcrypt.hash('test-password-123', 4);
+  const passwordHash = await hash('test-password-123', 4);
 
   const USERS_TO_SEED = [
     { username: 'admin_master', role: adminRole, camp: camp1, isAdmin: true },


### PR DESCRIPTION
Migrate from the pure JavaScript bcryptjs library to the native Rust-based
@node-rs/bcrypt implementation for faster password hashing. Update all imports across auth and users services, and remove the bcryptjs and @types/bcryptjs dependencies from package.json.