### PR TITLE
Fix AI admission request information

### DIFF
--- a/src/modules/admission/admission.service.ts
+++ b/src/modules/admission/admission.service.ts
@@ -158,24 +158,12 @@ export async function reviewAdmission(id: number, reviewedBy: number, data: Revi
         tx,
       );
 
-      return tx.admission_requests.update({
+      const linkedAdmission = await tx.admission_requests.update({
         where: { id: admission.id },
         data: { person_id: person.id },
       });
-      const linkedAdmission = await tx.admission_requests.update({
-        where: { id },
-        data: { person_id: person.id },
-      });
-
-      return {
-        ...linkedAdmission,
-        created_person: person,
-      };
+      return linkedAdmission;
     }
-
-    return {
-      ...admission,
-      created_person: null,
-    };
+    return admission;
   });
 }


### PR DESCRIPTION
This pull request simplifies the return values in the `reviewAdmission` function within `admission.service.ts`. Instead of returning an object that combines the admission data with a `created_person` property, the function now returns only the updated or original admission record, making the function's output more consistent and easier to handle.

Changes to return values:

* Simplified the return value of `reviewAdmission` to return only the `linkedAdmission` or `admission` object, removing the additional `created_person` property from the response.