### PR TITLE
Fix AI admission request information persistence

### DIFF
--- a/src/modules/admission/admission.service.ts
+++ b/src/modules/admission/admission.service.ts
@@ -158,24 +158,12 @@ export async function reviewAdmission(id: number, reviewedBy: number, data: Revi
         tx,
       );
 
-      return tx.admission_requests.update({
+      const linkedAdmission = await tx.admission_requests.update({
         where: { id: admission.id },
         data: { person_id: person.id },
       });
-      const linkedAdmission = await tx.admission_requests.update({
-        where: { id },
-        data: { person_id: person.id },
-      });
-
-      return {
-        ...linkedAdmission,
-        created_person: person,
-      };
+      return linkedAdmission;
     }
-
-    return {
-      ...admission,
-      created_person: null,
-    };
+    return admission;
   });
 }


### PR DESCRIPTION
This pull request simplifies the return values of the `reviewAdmission` function in `admission.service.ts` by removing the inclusion of the `created_person` property from the returned object. Now, the function returns only the updated admission record or the original admission record, without any additional merged data.

Logic simplification:

* Updated `reviewAdmission` to return only the updated or original admission record, removing the extra `created_person` property from the return value.