### PR TITLE
Fix API key fetching from worker

### DIFF
--- a/services/worker-go/.env.example
+++ b/services/worker-go/.env.example
@@ -1,5 +1,5 @@
 DATABASE_URL=postgresql://postgres:secret@localhost:5432/gestion_del_fin
-REDIS_JOBS_URL=redis://localhost:6379
+VALKEY_JOBS_URL=redis://localhost:6379
 CHILD_AGE=12
 MAX_RETRIES=3
 BASE_DELAY_SECONDS=5

--- a/services/worker-go/README.md
+++ b/services/worker-go/README.md
@@ -31,11 +31,11 @@ Notes:
  
 Queue / Daemon mode
 -------------------
-To run as a daemon that consumes work from Redis set `REDIS_JOBS_URL` and run the service. Example:
+To run as a daemon that consumes work from Valkey set `VALKEY_JOBS_URL` and run the service. Example:
 
 ```bash
-export REDIS_JOBS_URL=redis://:<password>@<host>:<port>
+export VALKEY_JOBS_URL=redis://:<password>@<host>:<port>
 go run ./main.go
 ```
 
-The API scheduler (`src/jobs/scheduler.ts`) will enqueue jobs to `jobs:daily_rations` when `REDIS_JOBS_URL` is set in the API environment. This allows a safe migration: keep the old in-process job as fallback and enable queueing by setting `REDIS_JOBS_URL`.
+The API scheduler (`src/jobs/scheduler.ts`) will enqueue jobs to `jobs:daily_rations` when `VALKEY_JOBS_URL` is set in the API environment. This allows a safe migration: keep the old in-process job as fallback and enable queueing by setting `VALKEY_JOBS_URL`.

--- a/services/worker-go/main.go
+++ b/services/worker-go/main.go
@@ -84,11 +84,11 @@ func main() {
     }
     defer pool.Close()
 
-    // If REDIS_JOBS_URL is set, run in daemon mode consuming jobs from Redis list.
-    redisUrl := os.Getenv("REDIS_JOBS_URL")
-    if redisUrl != "" {
+    // If VALKEY_JOBS_URL is set, run in daemon mode consuming jobs from the queue.
+    valkeyURL := os.Getenv("VALKEY_JOBS_URL")
+    if valkeyURL != "" {
         log.Printf("Starting worker in daemon mode (queues: %s, %s, %s)", jobQueueDailyRations, jobQueueDailyProduction, jobQueueResourceAlerts)
-        if err := runDaemon(ctx, pool, redisUrl, childAge); err != nil {
+        if err := runDaemon(ctx, pool, valkeyURL, childAge); err != nil {
             log.Fatalf("worker daemon failed: %v", err)
         }
         return
@@ -136,7 +136,7 @@ func runDaemon(ctx context.Context, pool *pgxpool.Pool, redisUrl string, childAg
 
     opt, err := rds.ParseURL(redisUrl)
     if err != nil {
-        return fmt.Errorf("invalid REDIS_JOBS_URL: %w", err)
+        return fmt.Errorf("invalid VALKEY_JOBS_URL: %w", err)
     }
     client := rds.NewClient(opt)
     defer client.Close()

--- a/src/jobs/scheduler.ts
+++ b/src/jobs/scheduler.ts
@@ -21,10 +21,10 @@ export function startJobScheduler() {
     logger.info('[JOB] Starting daily rations job');
 
     try {
-      const redisUrl = process.env.REDIS_JOBS_URL;
-      if (redisUrl) {
+      const valkeyUrl = process.env.VALKEY_JOBS_URL;
+      if (valkeyUrl) {
         try {
-          await enqueueDailyRations(redisUrl);
+          await enqueueDailyRations(valkeyUrl);
           logger.info('[JOB] Daily rations job enqueued');
         } catch (err) {
           logger.error('[JOB] Failed to enqueue daily rations job', err);
@@ -44,10 +44,10 @@ export function startJobScheduler() {
     logger.info('[JOB] Starting daily production job');
 
     try {
-      const redisUrl = process.env.REDIS_JOBS_URL;
-      if (redisUrl) {
+      const valkeyUrl = process.env.VALKEY_JOBS_URL;
+      if (valkeyUrl) {
         try {
-          await enqueueDailyProduction(redisUrl);
+          await enqueueDailyProduction(valkeyUrl);
           logger.info('[JOB] Daily production job enqueued');
         } catch (err) {
           logger.error('[JOB] Failed to enqueue daily production job', err);
@@ -67,10 +67,10 @@ export function startJobScheduler() {
     logger.info('[JOB] Starting resource alerts job');
 
     try {
-      const redisUrl = process.env.REDIS_JOBS_URL;
-      if (redisUrl) {
+      const valkeyUrl = process.env.VALKEY_JOBS_URL;
+      if (valkeyUrl) {
         try {
-          await enqueueResourceAlerts(redisUrl);
+          await enqueueResourceAlerts(valkeyUrl);
           logger.info('[JOB] Resource alerts job enqueued');
         } catch (err) {
           logger.error('[JOB] Failed to enqueue resource alerts job', err);


### PR DESCRIPTION
This pull request updates the job queue environment variable and related documentation and code to use `VALKEY_JOBS_URL` instead of the previous `REDIS_JOBS_URL`. This change is reflected across configuration files, documentation, and both Go and TypeScript code, ensuring consistency and preparing for a possible backend change or rebranding of the queue service.

**Environment variable and configuration updates:**

* Replaced `REDIS_JOBS_URL` with `VALKEY_JOBS_URL` in the `.env.example` file to standardize the new environment variable for queue configuration.

**Documentation updates:**

* Updated the `README.md` to instruct users to set `VALKEY_JOBS_URL` instead of `REDIS_JOBS_URL` for running the worker in daemon mode and for the API scheduler, including all relevant documentation references.

**Go backend updates:**

* Modified `main.go` so that the worker checks for `VALKEY_JOBS_URL` instead of `REDIS_JOBS_URL` to determine if it should run in daemon mode, and updated error messages and variable names accordingly. [[1]](diffhunk://#diff-9c35be40c8d3c06f75fed9a86b15547f223679754ef23392f3767ef6997353dfL87-R91) [[2]](diffhunk://#diff-9c35be40c8d3c06f75fed9a86b15547f223679754ef23392f3767ef6997353dfL139-R139)

**TypeScript scheduler updates:**

* Updated `src/jobs/scheduler.ts` to use `VALKEY_JOBS_URL` for all job enqueueing logic, replacing all instances of `REDIS_JOBS_URL` in environment variable checks and function calls. [[1]](diffhunk://#diff-9b4bf211643eaede8619ae36e1fa224db7f42564982565cfe8be847fecba85ffL24-R27) [[2]](diffhunk://#diff-9b4bf211643eaede8619ae36e1fa224db7f42564982565cfe8be847fecba85ffL47-R50) [[3]](diffhunk://#diff-9b4bf211643eaede8619ae36e1fa224db7f42564982565cfe8be847fecba85ffL70-R73)