### PR TITLE
Fix API key fetching in worker implementation

### DIFF
--- a/services/worker-go/.env.example
+++ b/services/worker-go/.env.example
@@ -1,5 +1,5 @@
 DATABASE_URL=postgresql://postgres:secret@localhost:5432/gestion_del_fin
-REDIS_JOBS_URL=redis://localhost:6379
+VALKEY_JOBS_URL=redis://localhost:6379
 CHILD_AGE=12
 MAX_RETRIES=3
 BASE_DELAY_SECONDS=5

--- a/services/worker-go/README.md
+++ b/services/worker-go/README.md
@@ -31,11 +31,11 @@ Notes:
  
 Queue / Daemon mode
 -------------------
-To run as a daemon that consumes work from Redis set `REDIS_JOBS_URL` and run the service. Example:
+To run as a daemon that consumes work from Valkey set `VALKEY_JOBS_URL` and run the service. Example:
 
 ```bash
-export REDIS_JOBS_URL=redis://:<password>@<host>:<port>
+export VALKEY_JOBS_URL=redis://:<password>@<host>:<port>
 go run ./main.go
 ```
 
-The API scheduler (`src/jobs/scheduler.ts`) will enqueue jobs to `jobs:daily_rations` when `REDIS_JOBS_URL` is set in the API environment. This allows a safe migration: keep the old in-process job as fallback and enable queueing by setting `REDIS_JOBS_URL`.
+The API scheduler (`src/jobs/scheduler.ts`) will enqueue jobs to `jobs:daily_rations` when `VALKEY_JOBS_URL` is set in the API environment. This allows a safe migration: keep the old in-process job as fallback and enable queueing by setting `VALKEY_JOBS_URL`.

--- a/services/worker-go/main.go
+++ b/services/worker-go/main.go
@@ -84,11 +84,11 @@ func main() {
     }
     defer pool.Close()
 
-    // If REDIS_JOBS_URL is set, run in daemon mode consuming jobs from Redis list.
-    redisUrl := os.Getenv("REDIS_JOBS_URL")
-    if redisUrl != "" {
+    // If VALKEY_JOBS_URL is set, run in daemon mode consuming jobs from the queue.
+    valkeyURL := os.Getenv("VALKEY_JOBS_URL")
+    if valkeyURL != "" {
         log.Printf("Starting worker in daemon mode (queues: %s, %s, %s)", jobQueueDailyRations, jobQueueDailyProduction, jobQueueResourceAlerts)
-        if err := runDaemon(ctx, pool, redisUrl, childAge); err != nil {
+        if err := runDaemon(ctx, pool, valkeyURL, childAge); err != nil {
             log.Fatalf("worker daemon failed: %v", err)
         }
         return
@@ -136,7 +136,7 @@ func runDaemon(ctx context.Context, pool *pgxpool.Pool, redisUrl string, childAg
 
     opt, err := rds.ParseURL(redisUrl)
     if err != nil {
-        return fmt.Errorf("invalid REDIS_JOBS_URL: %w", err)
+        return fmt.Errorf("invalid VALKEY_JOBS_URL: %w", err)
     }
     client := rds.NewClient(opt)
     defer client.Close()

--- a/src/jobs/scheduler.ts
+++ b/src/jobs/scheduler.ts
@@ -21,10 +21,10 @@ export function startJobScheduler() {
     logger.info('[JOB] Starting daily rations job');
 
     try {
-      const redisUrl = process.env.REDIS_JOBS_URL;
-      if (redisUrl) {
+      const valkeyUrl = process.env.VALKEY_JOBS_URL;
+      if (valkeyUrl) {
         try {
-          await enqueueDailyRations(redisUrl);
+          await enqueueDailyRations(valkeyUrl);
           logger.info('[JOB] Daily rations job enqueued');
         } catch (err) {
           logger.error('[JOB] Failed to enqueue daily rations job', err);
@@ -44,10 +44,10 @@ export function startJobScheduler() {
     logger.info('[JOB] Starting daily production job');
 
     try {
-      const redisUrl = process.env.REDIS_JOBS_URL;
-      if (redisUrl) {
+      const valkeyUrl = process.env.VALKEY_JOBS_URL;
+      if (valkeyUrl) {
         try {
-          await enqueueDailyProduction(redisUrl);
+          await enqueueDailyProduction(valkeyUrl);
           logger.info('[JOB] Daily production job enqueued');
         } catch (err) {
           logger.error('[JOB] Failed to enqueue daily production job', err);
@@ -67,10 +67,10 @@ export function startJobScheduler() {
     logger.info('[JOB] Starting resource alerts job');
 
     try {
-      const redisUrl = process.env.REDIS_JOBS_URL;
-      if (redisUrl) {
+      const valkeyUrl = process.env.VALKEY_JOBS_URL;
+      if (valkeyUrl) {
         try {
-          await enqueueResourceAlerts(redisUrl);
+          await enqueueResourceAlerts(valkeyUrl);
           logger.info('[JOB] Resource alerts job enqueued');
         } catch (err) {
           logger.error('[JOB] Failed to enqueue resource alerts job', err);


### PR DESCRIPTION
This pull request standardizes the naming of the environment variable used for the job queue backend, replacing all references to `REDIS_JOBS_URL` with `VALKEY_JOBS_URL` across the Go worker, TypeScript scheduler, environment example, and documentation. This change prepares the codebase for a possible migration from Redis to Valkey or clarifies the backend being used.

Key changes:

**Environment Variable Renaming:**
* All environment variable references for the job queue backend have been changed from `REDIS_JOBS_URL` to `VALKEY_JOBS_URL` in the `.env.example` file, Go worker code, TypeScript scheduler, and documentation. This includes updating variable names, log messages, error messages, and documentation instructions. [[1]](diffhunk://#diff-829f6e0a2c31701bf055ec82890093702f8ce06c8048e7e208b707e6d23a2d2aL2-R2) [[2]](diffhunk://#diff-9c35be40c8d3c06f75fed9a86b15547f223679754ef23392f3767ef6997353dfL87-R91) [[3]](diffhunk://#diff-9c35be40c8d3c06f75fed9a86b15547f223679754ef23392f3767ef6997353dfL139-R139) [[4]](diffhunk://#diff-9b4bf211643eaede8619ae36e1fa224db7f42564982565cfe8be847fecba85ffL24-R27) [[5]](diffhunk://#diff-9b4bf211643eaede8619ae36e1fa224db7f42564982565cfe8be847fecba85ffL47-R50) [[6]](diffhunk://#diff-9b4bf211643eaede8619ae36e1fa224db7f42564982565cfe8be847fecba85ffL70-R73) [[7]](diffhunk://#diff-118bb2f55bbc9b7959e4271e83864f5591020531b5adeddcb9bd2278215590f0L34-R41)

**Documentation Updates:**
* The `README.md` has been updated to instruct users to use `VALKEY_JOBS_URL` instead of `REDIS_JOBS_URL` and clarifies the environment variable to set for daemon mode and job scheduling.

**Scheduler and Worker Logic:**
* The Go worker (`main.go`) and TypeScript scheduler (`scheduler.ts`) now reference `VALKEY_JOBS_URL` for connecting to the job queue, ensuring consistent environment variable usage throughout the system. [[1]](diffhunk://#diff-9c35be40c8d3c06f75fed9a86b15547f223679754ef23392f3767ef6997353dfL87-R91) [[2]](diffhunk://#diff-9c35be40c8d3c06f75fed9a86b15547f223679754ef23392f3767ef6997353dfL139-R139) [[3]](diffhunk://#diff-9b4bf211643eaede8619ae36e1fa224db7f42564982565cfe8be847fecba85ffL24-R27) [[4]](diffhunk://#diff-9b4bf211643eaede8619ae36e1fa224db7f42564982565cfe8be847fecba85ffL47-R50) [[5]](diffhunk://#diff-9b4bf211643eaede8619ae36e1fa224db7f42564982565cfe8be847fecba85ffL70-R73)