### PR TITLE
Fix error handling for admission AI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,11 @@ CLOUDINARY_API_KEY=your_cloudinary_api_key_here
 CLOUDINARY_API_SECRET=your_cloudinary_api_secret_here
 CLOUDINARY_SIGNED_URL_MAX_TTL_SECONDS=600
 
-# ML Service
+# ─── ML Service ───────────────────────────────────────────────────────────────
+# Admission evaluation service. Required for production deployment.
+# Local: Set to http://localhost:8000 (requires 'docker compose up ml' to be running)
+# Railway: Set to the deployed ML service URL (e.g., https://ml-service-xxx.railway.app)
+# If unavailable, admissions will fall back to PENDING status for manual review.
 ML_SERVICE_URL=http://localhost:8000
 
 # Valkey for caching via Redis

--- a/src/ai/admission-evaluator.ts
+++ b/src/ai/admission-evaluator.ts
@@ -5,6 +5,7 @@ import {
   admissionAIResultSchema,
 } from '../modules/admission/admission.schema.js';
 import { AppError } from '../shared/utils/appError.js';
+import { logger } from '../logger/logger.js';
 import { z } from 'zod';
 
 const ML_SERVICE_URL = process.env.ML_SERVICE_URL ?? 'http://localhost:8000';
@@ -85,30 +86,46 @@ async function evaluateWithDecisionTree(
   reasoningPath: string[];
   professionCategory: string;
 }> {
-  const response = await fetch(`${ML_SERVICE_URL}/evaluate`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      age: data.applicant_age ?? null,
-      skills: data.applicant_skills ?? null,
-      health_notes: data.health_notes ?? null,
-      camp_weights: campWeights,
-    }),
-    signal: AbortSignal.timeout(5000),
-  });
+  try {
+    const response = await fetch(`${ML_SERVICE_URL}/evaluate`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        age: data.applicant_age ?? null,
+        skills: data.applicant_skills ?? null,
+        health_notes: data.health_notes ?? null,
+        camp_weights: campWeights,
+      }),
+      signal: AbortSignal.timeout(5000),
+    });
 
-  if (!response.ok) {
-    throw new AppError('Decision tree service unavailable', 502);
+    if (!response.ok) {
+      throw new AppError('Decision tree service unavailable', 502);
+    }
+
+    const result = await response.json();
+
+    return {
+      decision: result.decision,
+      confidence: result.confidence,
+      reasoningPath: result.reasoning_path,
+      professionCategory: result.profession_category,
+    };
+  } catch (error) {
+    if (error instanceof AppError) throw error;
+
+    const err = error as Error;
+    const errorDetails = {
+      mlServiceUrl: ML_SERVICE_URL,
+      errorName: err?.name ?? 'Unknown',
+      errorMessage: err?.message ?? 'No message',
+      isTimeout: err?.name === 'AbortError',
+    };
+
+    logger.error('ML service evaluation failed', errorDetails);
+
+    throw new AppError(`ML admission evaluation failed: ${err?.message ?? 'Unknown error'}`, 502);
   }
-
-  const result = await response.json();
-
-  return {
-    decision: result.decision,
-    confidence: result.confidence,
-    reasoningPath: result.reasoning_path,
-    professionCategory: result.profession_category,
-  };
 }
 
 function mapCategoryToProfession(

--- a/src/modules/admission/admission.schema.ts
+++ b/src/modules/admission/admission.schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 export const finalDecisionEnum = z.enum(['ACCEPTED', 'REJECTED']);
-export const aiDecisionEnum = z.enum(['ACCEPTED', 'REJECTED']);
+export const aiDecisionEnum = z.enum(['ACCEPTED', 'PENDING', 'REJECTED']);
 
 export const admissionAIResultSchema = z.object({
   ai_decision: aiDecisionEnum,

--- a/src/modules/admission/admission.service.ts
+++ b/src/modules/admission/admission.service.ts
@@ -74,13 +74,24 @@ export async function createAdmission(campId: number, data: CreateAdmissionDTO, 
   });
   if (professions.length === 0) throw new AppError('Professions not found', 404);
 
-  const campContext = camp.ai_context_prompt;
-
-  const aiResult = await evaluateAdmission(
-    data,
-    campContext ?? 'No context defined for this camp',
-    professions,
-  );
+  let aiResult: AdmissionAIResult;
+  try {
+    const campContext = camp.ai_context_prompt;
+    aiResult = await evaluateAdmission(
+      data,
+      campContext ?? 'No context defined for this camp',
+      professions,
+    );
+  } catch (error) {
+    // Fallback: Mark for manual review when AI evaluation fails
+    aiResult = {
+      ai_decision: 'PENDING',
+      ai_reasoning: `AI evaluation unavailable: ${(error as Error)?.message ?? 'Service error'}. Manual review required.`,
+      ai_confidence: 0,
+      ai_suggested_profession: professions[0]?.name ?? 'General Labor',
+      ai_profession_id: professions[0]?.id ?? 1,
+    };
+  }
 
   // Validate that the AI-suggested profession exists in this camp's professions list.
   // Guards against edge cases where the AI returns a fallback ID (e.g. 1) that does not


### PR DESCRIPTION
This pull request improves the reliability and transparency of the AI-powered admission evaluation process by enhancing error handling, updating schema definitions, and clarifying configuration. The changes ensure that if the ML service is unavailable or fails, admissions will be marked as "PENDING" for manual review, and detailed error logging is provided for better troubleshooting.

**Admission Evaluation Robustness:**

* Wrapped the ML service call in `evaluateWithDecisionTree` with a try/catch block to handle errors gracefully, log detailed error information, and throw a standardized `AppError` if evaluation fails (`src/ai/admission-evaluator.ts`). [[1]](diffhunk://#diff-a415b204704e64b9e127ca1d10f4aa83eece0b83e4678a7fc7f30038727028daR89) [[2]](diffhunk://#diff-a415b204704e64b9e127ca1d10f4aa83eece0b83e4678a7fc7f30038727028daR114-R128)
* Updated the admission creation flow to fall back to a "PENDING" AI decision with a descriptive reason and default profession if the ML service is unavailable or errors occur (`src/modules/admission/admission.service.ts`).

**Schema and Type Updates:**

* Extended the `aiDecisionEnum` to include "PENDING" as a possible AI decision, allowing the system to represent manual review states (`src/modules/admission/admission.schema.ts`).

**Configuration and Logging Improvements:**

* Added clarifying comments and instructions to the `.env.example` regarding the `ML_SERVICE_URL` variable, explaining its purpose and fallback behavior.
* Introduced the `logger` for structured error logging in the admission evaluator (`src/ai/admission-evaluator.ts`).