### PR TITLE
Fix IP reader in rate limit middleware

### DIFF
--- a/src/middlewares/rateLimit.middleware.ts
+++ b/src/middlewares/rateLimit.middleware.ts
@@ -1,6 +1,11 @@
-import rateLimit from 'express-rate-limit';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 
 const isTest = process.env.NODE_ENV === 'test';
+
+const getKey = (req: any) => {
+  const forwarded = req.headers['x-forwarded-for']?.toString().split(',')[0].trim();
+  return forwarded ? ipKeyGenerator(forwarded) : ipKeyGenerator(req.ip ?? 'unknown');
+};
 
 export const globalRateLimit = rateLimit({
   windowMs: 15 * 60 * 1000,
@@ -8,10 +13,7 @@ export const globalRateLimit = rateLimit({
   skip: () => isTest,
   standardHeaders: true,
   legacyHeaders: false,
-
-  keyGenerator: (req) => {
-    return req.headers['x-forwarded-for']?.toString().split(',')[0].trim() || req.ip || 'unknown';
-  },
+  keyGenerator: getKey,
   message: {
     error: {
       message: 'Too many requests, please try again later',
@@ -27,9 +29,7 @@ export const loginRateLimit = rateLimit({
   skipSuccessfulRequests: true,
   standardHeaders: true,
   legacyHeaders: false,
-  keyGenerator: (req) => {
-    return req.headers['x-forwarded-for']?.toString().split(',')[0].trim() || req.ip || 'unknown';
-  },
+  keyGenerator: getKey,
   message: {
     error: {
       message: 'Too many login attempts, please try again later',
@@ -44,9 +44,7 @@ export const admissionRateLimit = rateLimit({
   skip: () => isTest,
   standardHeaders: true,
   legacyHeaders: false,
-  keyGenerator: (req) => {
-    return req.headers['x-forwarded-for']?.toString().split(',')[0].trim() || req.ip || 'unknown';
-  },
+  keyGenerator: getKey,
   message: {
     error: {
       message: 'Too many admission requests, please try again later',


### PR DESCRIPTION
This pull request refactors how rate limiting keys are generated in the `rateLimit.middleware.ts` file. The main improvement is the introduction of a shared `getKey` function that uses the built-in `ipKeyGenerator` from `express-rate-limit`, ensuring more consistent and reliable IP extraction for rate limiting across all relevant middlewares.

**Refactoring and consistency improvements:**

* Introduced a new `getKey` function that uses `ipKeyGenerator` to standardize how client IP addresses are extracted for rate limiting, prioritizing the `x-forwarded-for` header and falling back to `req.ip` if needed.
* Updated `globalRateLimit`, `loginRateLimit`, and `admissionRateLimit` middlewares to use the new `getKey` function for their `keyGenerator` option, replacing the previous inline key generation logic. [[1]](diffhunk://#diff-26ae1ebd52dcf53d0efaa1206fc32a2bf69b77e58c02b0bca910fd66ac46a5deL1-R16) [[2]](diffhunk://#diff-26ae1ebd52dcf53d0efaa1206fc32a2bf69b77e58c02b0bca910fd66ac46a5deL30-R32) [[3]](diffhunk://#diff-26ae1ebd52dcf53d0efaa1206fc32a2bf69b77e58c02b0bca910fd66ac46a5deL47-R47)