### PR TITLE
Fix IP reader in rate limit middleware

### DIFF
--- a/src/middlewares/rateLimit.middleware.ts
+++ b/src/middlewares/rateLimit.middleware.ts
@@ -1,6 +1,11 @@
-import rateLimit from 'express-rate-limit';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 
 const isTest = process.env.NODE_ENV === 'test';
+
+const getKey = (req: any) => {
+  const forwarded = req.headers['x-forwarded-for']?.toString().split(',')[0].trim();
+  return forwarded ? ipKeyGenerator(forwarded) : ipKeyGenerator(req.ip ?? 'unknown');
+};
 
 export const globalRateLimit = rateLimit({
   windowMs: 15 * 60 * 1000,
@@ -8,10 +13,7 @@ export const globalRateLimit = rateLimit({
   skip: () => isTest,
   standardHeaders: true,
   legacyHeaders: false,
-
-  keyGenerator: (req) => {
-    return req.headers['x-forwarded-for']?.toString().split(',')[0].trim() || req.ip || 'unknown';
-  },
+  keyGenerator: getKey,
   message: {
     error: {
       message: 'Too many requests, please try again later',
@@ -27,9 +29,7 @@ export const loginRateLimit = rateLimit({
   skipSuccessfulRequests: true,
   standardHeaders: true,
   legacyHeaders: false,
-  keyGenerator: (req) => {
-    return req.headers['x-forwarded-for']?.toString().split(',')[0].trim() || req.ip || 'unknown';
-  },
+  keyGenerator: getKey,
   message: {
     error: {
       message: 'Too many login attempts, please try again later',
@@ -44,9 +44,7 @@ export const admissionRateLimit = rateLimit({
   skip: () => isTest,
   standardHeaders: true,
   legacyHeaders: false,
-  keyGenerator: (req) => {
-    return req.headers['x-forwarded-for']?.toString().split(',')[0].trim() || req.ip || 'unknown';
-  },
+  keyGenerator: getKey,
   message: {
     error: {
       message: 'Too many admission requests, please try again later',


### PR DESCRIPTION
This pull request refactors the way rate limit keys are generated in the `rateLimit.middleware.ts` file. The main improvement is the introduction of a reusable `getKey` function that leverages the `ipKeyGenerator` from `express-rate-limit` for consistent and reliable IP extraction, especially when handling proxies and the `x-forwarded-for` header.

**Rate limiting improvements:**

* Introduced a shared `getKey` function that uses `ipKeyGenerator` to standardize key generation logic across all rate limiters, improving maintainability and reliability.
* Updated the `keyGenerator` property in `globalRateLimit`, `loginRateLimit`, and `admissionRateLimit` to use the new `getKey` function instead of duplicating logic, ensuring consistent behavior for rate limiting throughout the middleware. [[1]](diffhunk://#diff-26ae1ebd52dcf53d0efaa1206fc32a2bf69b77e58c02b0bca910fd66ac46a5deL1-R16) [[2]](diffhunk://#diff-26ae1ebd52dcf53d0efaa1206fc32a2bf69b77e58c02b0bca910fd66ac46a5deL30-R32) [[3]](diffhunk://#diff-26ae1ebd52dcf53d0efaa1206fc32a2bf69b77e58c02b0bca910fd66ac46a5deL47-R47)