### PR TITLE
Add toggable rate limiter using environment variable

### DIFF
--- a/src/middlewares/rateLimit.middleware.ts
+++ b/src/middlewares/rateLimit.middleware.ts
@@ -10,7 +10,7 @@ const getKey = (req: any) => {
 export const globalRateLimit = rateLimit({
   windowMs: 15 * 60 * 1000,
   max: 200,
-  skip: () => isTest,
+  skip: () => isTest || process.env.DISABLE_RATE_LIMIT === 'true',
   standardHeaders: true,
   legacyHeaders: false,
   keyGenerator: getKey,
@@ -25,7 +25,7 @@ export const globalRateLimit = rateLimit({
 export const loginRateLimit = rateLimit({
   windowMs: isTest ? 60 * 1000 : 15 * 60 * 1000,
   max: isTest ? 100 : 5,
-  skip: () => isTest,
+  skip: () => isTest || process.env.DISABLE_RATE_LIMIT === 'true',
   skipSuccessfulRequests: true,
   standardHeaders: true,
   legacyHeaders: false,
@@ -41,7 +41,7 @@ export const loginRateLimit = rateLimit({
 export const admissionRateLimit = rateLimit({
   windowMs: 60 * 1000,
   max: 10,
-  skip: () => isTest,
+  skip: () => isTest || process.env.DISABLE_RATE_LIMIT === 'true',
   standardHeaders: true,
   legacyHeaders: false,
   keyGenerator: getKey,


### PR DESCRIPTION
This pull request updates the rate limiting middleware to allow rate limiting to be disabled via an environment variable. This provides more flexibility for different deployment scenarios, such as local development or specific testing environments.

**Rate limiting configuration:**

* Updated all rate limiters (`globalRateLimit`, `loginRateLimit`, and `admissionRateLimit` in `src/middlewares/rateLimit.middleware.ts`) to skip rate limiting if the environment variable `DISABLE_RATE_LIMIT` is set to `'true'`, in addition to the existing `isTest` check. [[1]](diffhunk://#diff-26ae1ebd52dcf53d0efaa1206fc32a2bf69b77e58c02b0bca910fd66ac46a5deL13-R13) [[2]](diffhunk://#diff-26ae1ebd52dcf53d0efaa1206fc32a2bf69b77e58c02b0bca910fd66ac46a5deL28-R28) [[3]](diffhunk://#diff-26ae1ebd52dcf53d0efaa1206fc32a2bf69b77e58c02b0bca910fd66ac46a5deL44-R44)